### PR TITLE
#247: Implement --pretend option for move

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1414,7 +1414,7 @@ class Library(BaseLibrary):
         self._memotable = {}
 
     def move(self, item, copy=False, basedir=None,
-             with_album=True):
+             with_album=True, pretend=False):
         """Move the item to its designated location within the library
         directory (provided by destination()). Subdirectories are
         created as needed. If the operation succeeds, the item's path
@@ -1435,6 +1435,8 @@ class Library(BaseLibrary):
         transaction.
         """
         dest = self.destination(item, basedir=basedir)
+        if pretend:
+            return dest
 
         # Create necessary ancestry for the move.
         util.mkdirall(dest)
@@ -1676,7 +1678,7 @@ class Album(BaseAlbum):
             util.prune_dirs(os.path.dirname(old_art),
                             self._library.directory)
 
-    def move(self, copy=False, basedir=None):
+    def move(self, copy=False, basedir=None, pretend=False):
         """Moves (or copies) all items to their destination.  Any album
         art moves along with them. basedir overrides the library base
         directory for the destination.
@@ -1686,7 +1688,10 @@ class Album(BaseAlbum):
         # Move items.
         items = list(self.items())
         for item in items:
-            self._library.move(item, copy, basedir=basedir, with_album=False)
+            _ = self._library.move(item, copy, basedir=basedir,
+                                   with_album=False, pretend=pretend)
+            if pretend:
+                return _
 
         # Move art.
         self.move_art(copy)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1190,7 +1190,7 @@ default_commands.append(modify_cmd)
 
 # move: Move/copy files to the library or a new base directory.
 
-def move_items(lib, dest, query, copy, album):
+def move_items(lib, dest, query, copy, album, pretend):
     """Moves or copies items to a new base directory, given by dest. If
     dest is None, then the library's base directory is used, making the
     command "consolidate" files.
@@ -1206,10 +1206,13 @@ def move_items(lib, dest, query, copy, album):
         logging.debug('moving: %s' % old_path)
 
         if album:
-            obj.move(copy, basedir=dest)
+            _ = obj.move(copy, basedir=dest, pretend=pretend)
         else:
-            lib.move(obj, copy, basedir=dest)
-            lib.store(obj)
+            _ = lib.move(obj, copy, basedir=dest, pretend=pretend)
+            if not pretend:
+                lib.store(obj)
+        if pretend:
+            print_("{} -> {}".format(obj.path, _))
 
 move_cmd = ui.Subcommand('move',
     help='move or copy items', aliases=('mv',))
@@ -1217,6 +1220,9 @@ move_cmd.parser.add_option('-d', '--dest', metavar='DIR', dest='dest',
     help='destination directory')
 move_cmd.parser.add_option('-c', '--copy', default=False, action='store_true',
     help='copy instead of moving')
+move_cmd.parser.add_option('-p', '--pretend', default=False,
+    action='store_true',
+    help='show how files would be moved, but don\'t touch anything')
 move_cmd.parser.add_option('-a', '--album', default=False, action='store_true',
     help='match whole albums instead of tracks')
 def move_func(lib, opts, args):
@@ -1226,6 +1232,6 @@ def move_func(lib, opts, args):
         if not os.path.isdir(dest):
             raise ui.UserError('no such directory: %s' % dest)
 
-    move_items(lib, dest, decargs(args), opts.copy, opts.album)
+    move_items(lib, dest, decargs(args), opts.copy, opts.album, opts.pretend)
 move_cmd.func = move_func
 default_commands.append(move_cmd)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -236,8 +236,9 @@ class MoveTest(_common.TestCase):
         # Alternate destination directory.
         self.otherdir = os.path.join(self.temp_dir, 'testotherdir')
 
-    def _move(self, query=(), dest=None, copy=False, album=False):
-        commands.move_items(self.lib, dest, query, copy, album)
+    def _move(self, query=(), dest=None, copy=False, album=False,
+              pretend=False):
+        commands.move_items(self.lib, dest, query, copy, album, pretend)
 
     def test_move_item(self):
         self._move()


### PR DESCRIPTION
This adds support for a "--pretend"/"-p" option for the 'move' command, as requested in issue #247.
The code changes the behaviour of the move methods to return the destination path as a string if the pretend option is set, which is then displayed in the UI.