### PR TITLE
Refactor ftintitle

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -95,7 +95,7 @@ def find_feat_part(artist, albumartist):
     # featuring artist on the left-hand side.
     else:
         lhs, rhs = split_on_feat(albumartist_split[0])
-        if rhs:
+        if lhs:
             feat_part = lhs
 
     return feat_part

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -118,6 +118,8 @@ def ft_in_title(item, drop_feat, loglevel=logging.DEBUG):
     if featured and albumartist != artist and albumartist:
         log.log(loglevel, displayable_path(item.path))
 
+        feat_part = None
+
         # Attempt to find the featured artist
         try:
             feat_part = find_feat_part(artist, albumartist)

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -24,14 +24,6 @@ import re
 log = logging.getLogger('beets')
 
 
-class ArtistNotFoundException(Exception):
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)
-
-
 def split_on_feat(artist):
     """Given an artist string, split the "main" artist from any artist
     on the right-hand side of a string like "feat". Return the main
@@ -85,7 +77,7 @@ def find_feat_part(artist, albumartist):
     # present, give up.
     albumartist_split = artist.split(albumartist, 1)
     if len(albumartist_split) <= 1:
-        raise ArtistNotFoundException('album artist not present in artist')
+        return feat_part
 
     # If the last element of the split (the right-hand side of the
     # album artist) is nonempty, then it probably contains the
@@ -121,10 +113,7 @@ def ft_in_title(item, drop_feat, loglevel=logging.DEBUG):
         feat_part = None
 
         # Attempt to find the featured artist
-        try:
-            feat_part = find_feat_part(artist, albumartist)
-        except ArtistNotFoundException:
-            log.log(loglevel, 'album artist not present in artist')
+        feat_part = find_feat_part(artist, albumartist)
 
         # If we have a featuring artist, move it to the title.
         if feat_part:

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -23,11 +23,14 @@ import re
 
 log = logging.getLogger('beets')
 
+
 class ArtistNotFoundException(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
+
 
 def split_on_feat(artist):
     """Given an artist string, split the "main" artist from any artist
@@ -99,6 +102,7 @@ def find_feat_part(artist, albumartist):
             feat_part = lhs
 
     return feat_part
+
 
 def ft_in_title(item, drop_feat, loglevel=logging.DEBUG):
     """Look for featured artists in the item's artist fields and move

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -23,6 +23,21 @@ class FtInTitlePluginTest(unittest.TestCase):
         """Set up configuration"""
         ftintitle.FtInTitlePlugin()
 
+    def test_find_feat_part(self):
+        test_cases = [
+            {'artist': 'Alice ft. Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice feat Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice featuring Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice & Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice and Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice With Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
+            {'artist': 'Alice defeat Bob', 'album_artist': 'Alice', 'feat_part': None},
+        ]
+
+        for test_case in test_cases:
+            feat_part = ftintitle.find_feat_part(test_case['artist'], test_case['album_artist'])
+            self.assertEqual(feat_part, test_case['feat_part'])
+
     def test_split_on_feat(self):
         parts = ftintitle.split_on_feat('Alice ft. Bob')
         self.assertEqual(parts, ('Alice', 'Bob'))

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -32,6 +32,8 @@ class FtInTitlePluginTest(unittest.TestCase):
             {'artist': 'Alice and Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
             {'artist': 'Alice With Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
             {'artist': 'Alice defeat Bob', 'album_artist': 'Alice', 'feat_part': None},
+            {'artist': 'Alice & Bob', 'album_artist': 'Bob', 'feat_part': 'Alice'},
+            {'artist': 'Alice ft. Bob', 'album_artist': 'Bob', 'feat_part': 'Alice'},
         ]
 
         for test_case in test_cases:

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -25,19 +25,58 @@ class FtInTitlePluginTest(unittest.TestCase):
 
     def test_find_feat_part(self):
         test_cases = [
-            {'artist': 'Alice ft. Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice feat Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice featuring Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice & Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice and Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice With Bob', 'album_artist': 'Alice', 'feat_part': 'Bob'},
-            {'artist': 'Alice defeat Bob', 'album_artist': 'Alice', 'feat_part': None},
-            {'artist': 'Alice & Bob', 'album_artist': 'Bob', 'feat_part': 'Alice'},
-            {'artist': 'Alice ft. Bob', 'album_artist': 'Bob', 'feat_part': 'Alice'},
+            {
+                'artist': 'Alice ft. Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice feat Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice featuring Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice & Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice and Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice With Bob',
+                'album_artist': 'Alice',
+                'feat_part': 'Bob'
+            },
+            {
+                'artist': 'Alice defeat Bob',
+                'album_artist': 'Alice',
+                'feat_part': None
+            },
+            {
+                'artist': 'Alice & Bob',
+                'album_artist': 'Bob',
+                'feat_part': 'Alice'
+            },
+            {
+                'artist': 'Alice ft. Bob',
+                'album_artist': 'Bob',
+                'feat_part': 'Alice'
+            },
         ]
 
         for test_case in test_cases:
-            feat_part = ftintitle.find_feat_part(test_case['artist'], test_case['album_artist'])
+            feat_part = ftintitle.find_feat_part(
+                test_case['artist'],
+                test_case['album_artist']
+            )
             self.assertEqual(feat_part, test_case['feat_part'])
 
     def test_split_on_feat(self):


### PR DESCRIPTION
Refactor the `ftintitle` plugin to move the extraction of the featured artist from the artist string into it's own function so that it can be tested.

This also fixes a bug that was in the original code that extracted the featured artist that would cause it to fail if the album artist was on the right side and the featured artist on the left side in the artist field. Also adds test cases to avoid this bug resurfacing.