### PR TITLE
Small cleans in beets.util module

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -544,10 +544,7 @@ def truncate_path(path, length=MAX_FILENAME_LENGTH):
 
 def str2bool(value):
     """Returns a boolean reflecting a human-entered string."""
-    if value.lower() in ('yes', '1', 'true', 't', 'y'):
-        return True
-    else:
-        return False
+    return value.lower() in ('yes', '1', 'true', 't', 'y')
 
 
 def as_string(value):

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -20,7 +20,7 @@ import sys
 import re
 import shutil
 import fnmatch
-from collections import defaultdict
+from collections import defaultdict, Counter
 import traceback
 import subprocess
 import platform
@@ -588,27 +588,14 @@ def levenshtein(s1, s2):
 
 
 def plurality(objs):
-    """Given a sequence of comparable objects, returns the object that
-    is most common in the set and the frequency of that object. The
+    """Given a sequence of hashble objects, returns the object that
+    is most common in the set and the its number of appearance. The
     sequence must contain at least one object.
     """
-    # Calculate frequencies.
-    freqs = defaultdict(int)
-    for obj in objs:
-        freqs[obj] += 1
-
-    if not freqs:
+    c = Counter(objs)
+    if not c:
         raise ValueError('sequence must be non-empty')
-
-    # Find object with maximum frequency.
-    max_freq = 0
-    res = None
-    for obj, freq in freqs.items():
-        if freq > max_freq:
-            max_freq = freq
-            res = obj
-
-    return res, max_freq
+    return c.most_common(1)[0]
 
 
 def cpu_count():

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -20,7 +20,7 @@ import sys
 import re
 import shutil
 import fnmatch
-from collections import defaultdict, Counter
+from collections import Counter
 import traceback
 import subprocess
 import platform


### PR DESCRIPTION
Looking at the barriers to python 3 I entered `beets/util/__init__.py`. Reading its source took my attention to 2 small functions that could be cleaner and faster. I rewrote them, here it is.

- `str2bool`:  if/else was unwarranted. Note than in python3 using a set will be better (optimized as a frozenset loaded in 1 operation)
- `plurality`: this is what `Counter` is for!