### PR TITLE
Don't crash when no argument is given

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -924,7 +924,8 @@ def _raw_main(args, lib=None):
     # Special case for the `config --edit` command: bypass _setup so
     # that an invalid configuration does not prevent the editor from
     # starting.
-    if subargs[0] == 'config' and ('-e' in subargs or '--edit' in subargs):
+    if subargs and subargs[0] == 'config' \
+       and ('-e' in subargs or '--edit' in subargs):
         from beets.ui.commands import config_edit
         return config_edit()
 


### PR DESCRIPTION
Check that there is a sub-argument before getting the first one. Fixes issue #1205 