### PR TITLE
 Use a standard logger for the import log

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -234,8 +234,8 @@ class ImportSession(object):
         self.want_resume = config['resume'].as_choice([True, False, 'ask'])
 
     def tag_log(self, status, paths):
-        """Log a message about a given album to the log file. The status should
-        reflect the reason the album couldn't be tagged.
+        """Log a message about a given album to the importer log. The status
+        should reflect the reason the album couldn't be tagged.
         """
         self.logger.info(u'{0} {1}', status, displayable_path(paths))
 

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -195,7 +195,6 @@ class ImportSession(object):
         logger = logging.getLogger(__name__)
         logger.propagate = False
         if not loghandler:
-            log.info(u"Importer progress won't be logged")
             loghandler = logging.NullHandler()
         logger.handlers = [loghandler]
         return logger

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -92,3 +92,16 @@ if PY26:
         return logger
 
     my_manager.getLogger = new_getLogger
+
+
+# Offer NullHandler in Python 2.6 to reduce the difference with never versions
+if PY26:
+    class NullHandler(Handler):
+        def handle(self, record):
+            pass
+
+        def emit(self, record):
+            pass
+
+        def createLock(self):
+            self.lock = None

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -18,8 +18,6 @@ interface.
 from __future__ import print_function
 
 import os
-import time
-import codecs
 import platform
 import re
 import shlex
@@ -825,29 +823,22 @@ def import_files(lib, paths, query):
 
     # Open the log.
     if config['import']['log'].get() is not None:
-        logpath = config['import']['log'].as_filename()
+        logpath = syspath(config['import']['log'].as_filename())
         try:
-            logfile = codecs.open(syspath(logpath), 'a', 'utf8')
+            loghandler = logging.FileHandler(logpath)
         except IOError:
-            raise ui.UserError(u"could not open log file for writing: %s" %
-                               displayable_path(logpath))
-        print(u'import started', time.asctime(), file=logfile)
+            raise ui.UserError(u"could not open log file for writing: "
+                               u"{0}".format(displayable_path(loghandler)))
     else:
-        logfile = None
+        loghandler = None
 
     # Never ask for input in quiet mode.
     if config['import']['resume'].get() == 'ask' and \
             config['import']['quiet']:
         config['import']['resume'] = False
 
-    session = TerminalImportSession(lib, logfile, paths, query)
-    try:
-        session.run()
-    finally:
-        # If we were logging, close the file.
-        if logfile:
-            print(u'', file=logfile)
-            logfile.close()
+    session = TerminalImportSession(lib, loghandler, paths, query)
+    session.run()
 
     # Emit event.
     plugins.send('import', lib=lib, paths=paths)

--- a/test/_common.py
+++ b/test/_common.py
@@ -115,9 +115,9 @@ def album(lib=None):
 
 
 # Dummy import session.
-def import_session(lib=None, logfile=None, paths=[], query=[], cli=False):
+def import_session(lib=None, loghandler=None, paths=[], query=[], cli=False):
     cls = commands.TerminalImportSession if cli else importer.ImportSession
-    return cls(lib, logfile, paths, query)
+    return cls(lib, loghandler, paths, query)
 
 
 # A test harness for all beets tests.

--- a/test/helper.py
+++ b/test/helper.py
@@ -255,7 +255,7 @@ class TestHelper(object):
         config['import']['autotag'] = False
         config['import']['resume'] = False
 
-        return TestImportSession(self.lib, logfile=None, query=None,
+        return TestImportSession(self.lib, loghandler=None, query=None,
                                  paths=[import_dir])
 
     # Library fixtures methods

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -33,6 +33,7 @@ from beets.mediafile import MediaFile
 from beets import autotag
 from beets.autotag import AlbumInfo, TrackInfo, AlbumMatch
 from beets import config
+from beets import logging
 
 
 class AutotagStub(object):
@@ -209,7 +210,7 @@ class ImportHelper(TestHelper):
         config['import']['link'] = link
 
         self.importer = TestImportSession(
-            self.lib, logfile=None, query=None,
+            self.lib, loghandler=None, query=None,
             paths=[import_dir or self.import_dir]
         )
 
@@ -1219,13 +1220,15 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper):
 class TagLogTest(_common.TestCase):
     def test_tag_log_line(self):
         sio = StringIO.StringIO()
-        session = _common.import_session(logfile=sio)
+        handler = logging.StreamHandler(sio)
+        session = _common.import_session(loghandler=handler)
         session.tag_log('status', 'path')
         assert 'status path' in sio.getvalue()
 
     def test_tag_log_unicode(self):
         sio = StringIO.StringIO()
-        session = _common.import_session(logfile=sio)
+        handler = logging.StreamHandler(sio)
+        session = _common.import_session(loghandler=handler)
         session.tag_log('status', 'caf\xc3\xa9')
         assert 'status caf' in sio.getvalue()
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file is part of beets.
 # Copyright 2015, Adrian Sampson.
 #
@@ -1223,14 +1224,14 @@ class TagLogTest(_common.TestCase):
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
         session.tag_log('status', 'path')
-        assert 'status path' in sio.getvalue()
+        self.assertIn('status path', sio.getvalue())
 
     def test_tag_log_unicode(self):
         sio = StringIO.StringIO()
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
-        session.tag_log('status', 'caf\xc3\xa9')
-        assert 'status caf' in sio.getvalue()
+        session.tag_log('status', u'café')  # send unicode
+        self.assertIn(u'status café', sio.getvalue())
 
 
 class ResumeImportTest(unittest.TestCase, TestHelper):

--- a/test/test_ui_importer.py
+++ b/test/test_ui_importer.py
@@ -91,7 +91,7 @@ class TerminalImportSessionSetup(object):
             self.io = DummyIO()
         self.io.install()
         self.importer = TestTerminalImportSession(
-            self.lib, logfile=None, query=None, io=self.io,
+            self.lib, loghandler=None, query=None, io=self.io,
             paths=[import_dir or self.import_dir],
         )
 


### PR DESCRIPTION
The import log relies on a standard logger, named 'beets.importer' and configured upon initialization of the import session.
Small improvement to the related unit tests.
Related to #1044.