### PR TITLE
Clean plugins: no global, no print

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -185,7 +185,8 @@ class BeetsPlugin(object):
         """
         if cls.listeners is None:
             cls.listeners = defaultdict(list)
-        cls.listeners[event].append(func)
+        if func not in cls.listeners[event]:
+            cls.listeners[event].append(func)
 
     @classmethod
     def listen(cls, event):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -202,9 +202,7 @@ class BeetsPlugin(object):
             ...     pass
         """
         def helper(func):
-            if cls.listeners is None:
-                cls.listeners = defaultdict(list)
-            cls.listeners[event].append(func)
+            cls.register_listener(event, func)
             return func
         return helper
 

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -81,11 +81,11 @@ class MPDUpdatePlugin(BeetsPlugin):
         self.register_listener('cli_exit', self.update)
 
     def update(self, lib):
-            self.update_mpd(
-                config['mpd']['host'].get(unicode),
-                config['mpd']['port'].get(int),
-                config['mpd']['password'].get(unicode),
-            )
+        self.update_mpd(
+            config['mpd']['host'].get(unicode),
+            config['mpd']['port'].get(int),
+            config['mpd']['password'].get(unicode),
+        )
 
     def update_mpd(self, host='localhost', port=6600, password=None):
         """Sends the "update" command to the MPD server indicated,

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -20,16 +20,10 @@ Put something like the following in your config.yaml to configure:
         port: 6600
         password: seekrit
 """
-from __future__ import print_function
-
 from beets.plugins import BeetsPlugin
 import os
 import socket
 from beets import config
-
-# Global variable so that mpdupdate can detect database changes and run only
-# once before beets exits.
-database_changed = False
 
 
 # No need to introduce a dependency on an MPD library for such a
@@ -66,37 +60,6 @@ class BufferedSocket(object):
         self.sock.close()
 
 
-def update_mpd(host='localhost', port=6600, password=None):
-    """Sends the "update" command to the MPD server indicated,
-    possibly authenticating with a password first.
-    """
-    print('Updating MPD database...')
-
-    s = BufferedSocket(host, port)
-    resp = s.readline()
-    if 'OK MPD' not in resp:
-        print('MPD connection failed:', repr(resp))
-        return
-
-    if password:
-        s.send('password "%s"\n' % password)
-        resp = s.readline()
-        if 'OK' not in resp:
-            print('Authentication failed:', repr(resp))
-            s.send('close\n')
-            s.close()
-            return
-
-    s.send('update\n')
-    resp = s.readline()
-    if 'updating_db' not in resp:
-        print('Update failed:', repr(resp))
-
-    s.send('close\n')
-    s.close()
-    print('... updated.')
-
-
 class MPDUpdatePlugin(BeetsPlugin):
     def __init__(self):
         super(MPDUpdatePlugin, self).__init__()
@@ -112,18 +75,44 @@ class MPDUpdatePlugin(BeetsPlugin):
             if self.config[key].exists():
                 config['mpd'][key] = self.config[key].get()
 
+        self.register_listener('database_change', self.db_change)
 
-@MPDUpdatePlugin.listen('database_change')
-def handle_change(lib=None):
-    global database_changed
-    database_changed = True
+    def db_change(self, lib):
+        self.register_listener('cli_exit', self.update)
 
+    def update(self, lib):
+            self.update_mpd(
+                config['mpd']['host'].get(unicode),
+                config['mpd']['port'].get(int),
+                config['mpd']['password'].get(unicode),
+            )
 
-@MPDUpdatePlugin.listen('cli_exit')
-def update(lib=None):
-    if database_changed:
-        update_mpd(
-            config['mpd']['host'].get(unicode),
-            config['mpd']['port'].get(int),
-            config['mpd']['password'].get(unicode),
-        )
+    def update_mpd(self, host='localhost', port=6600, password=None):
+        """Sends the "update" command to the MPD server indicated,
+        possibly authenticating with a password first.
+        """
+        self._log.info('Updating MPD database...')
+
+        s = BufferedSocket(host, port)
+        resp = s.readline()
+        if 'OK MPD' not in resp:
+            self._log.warning(u'MPD connection failed: {0!r}', resp)
+            return
+
+        if password:
+            s.send('password "%s"\n' % password)
+            resp = s.readline()
+            if 'OK' not in resp:
+                self._log.warning(u'Authentication failed: {0!r}', resp)
+                s.send('close\n')
+                s.close()
+                return
+
+        s.send('update\n')
+        resp = s.readline()
+        if 'updating_db' not in resp:
+            self._log.warning(u'Update failed: {0!r}', resp)
+
+        s.send('close\n')
+        s.close()
+        self._log.info('Database updated.')

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -25,7 +25,8 @@ import os
 
 def _items_for_query(lib, queries, album):
     """Get the matching items for a query.
-    `album` indicates whether the queries are item-level or album-level"""
+    `album` indicates whether the queries are item-level or album-level.
+    """
     request = lib.albums if album else lib.items
     if isinstance(queries, basestring):
         return request(queries)

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -53,9 +53,9 @@ to albums that have a ``for_travel`` extensible field set to 1::
       album_query: 'for_travel:1'
       query: 'for_travel:1'
 
-By default, all playlists are automatically regenerated after every beets
-command that changes the library database. To force regeneration, you can invoke it manually from the
-command line::
+By default, all playlists are automatically regenerated at the end of the
+session if the library database was changed. To force regeneration, you can
+invoke it manually from the command line::
 
     $ beet splupdate
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -161,6 +161,41 @@ class HelpersTest(unittest.TestCase):
                          ('A', 'B', 'C', 'D')), ['D', 'B', 'C', 'A'])
 
 
+class ListenersTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_plugin_loader()
+
+    def tearDown(self):
+        self.teardown_plugin_loader()
+        self.teardown_beets()
+
+    def test_register(self):
+
+        class DummyPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super(DummyPlugin, self).__init__()
+                self.register_listener('cli_exit', self.dummy)
+                self.register_listener('cli_exit', self.dummy)
+
+            def dummy(self):
+                pass
+
+        d = DummyPlugin()
+        self.assertEqual(DummyPlugin.listeners['cli_exit'], [d.dummy])
+
+        d2 = DummyPlugin()
+        DummyPlugin.register_listener('cli_exit', d.dummy)
+        self.assertEqual(DummyPlugin.listeners['cli_exit'],
+                         [d.dummy, d2.dummy])
+
+        @DummyPlugin.listen('cli_exit')
+        def dummy(lib):
+            pass
+
+        self.assertEqual(DummyPlugin.listeners['cli_exit'],
+                         [d.dummy, d2.dummy, dummy])
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 


### PR DESCRIPTION
Those commits clean `smartplaylist`, `plexupdate` and `mpdupdate`: they use their logger, and they don't rely on a `global` variable any more.
That last point is thanks to an update of `BeetsPlugin.register_listener` which now checks that the target function of a listener is not already registered.