### PR TITLE
Stop on invalid queries instead of ignoring them

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -147,6 +147,9 @@ class SubstringQuery(StringFieldQuery):
 class RegexpQuery(StringFieldQuery):
     """A query that matches a regular expression in a specific item
     field.
+
+    Raises InvalidQueryError when the pattern is not a valid regular
+    expression.
     """
     def __init__(self, field, pattern, false=True):
         super(RegexpQuery, self).__init__(field, pattern, false)
@@ -203,6 +206,9 @@ class NumericQuery(FieldQuery):
     """Matches numeric fields. A syntax using Ruby-style range ellipses
     (``..``) lets users specify one- or two-sided ranges. For example,
     ``year:2001..`` finds music released since the turn of the century.
+
+    Raises InvalidQueryError when the pattern does not represent an int or
+    a float.
     """
     def _convert(self, s):
         """Convert a string to a numeric type (float or int). If the

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -20,12 +20,12 @@ from beets import util
 from datetime import datetime, timedelta
 
 
-class InvalidQuery(ValueError):
+class InvalidQueryError(ValueError):
     def __init__(self, what, expected, detail=None):
         message = "{0!r} is not {1}".format(what, expected)
         if detail:
             message = "{0}: {1}".format(message, detail)
-        super(InvalidQuery, self).__init__(message)
+        super(InvalidQueryError, self).__init__(message)
 
 
 class Query(object):
@@ -154,7 +154,8 @@ class RegexpQuery(StringFieldQuery):
             self.pattern = re.compile(self.pattern)
         except re.error as exc:
             # Invalid regular expression.
-            raise InvalidQuery(pattern, "a regular expression", format(exc))
+            raise InvalidQueryError(pattern, "a regular expression",
+                                    format(exc))
 
     @classmethod
     def string_match(cls, pattern, value):
@@ -214,7 +215,7 @@ class NumericQuery(FieldQuery):
             try:
                 return float(s)
             except ValueError:
-                raise InvalidQuery(s, "an int or a float")
+                raise InvalidQueryError(s, "an int or a float")
 
     def __init__(self, field, pattern, fast=True):
         super(NumericQuery, self).__init__(field, pattern, fast)

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -961,7 +961,7 @@ def main(args=None):
     except confit.ConfigError as exc:
         log.error(u'configuration error: {0}', exc)
         sys.exit(1)
-    except db_query.InvalidQuery as exc:
+    except db_query.InvalidQueryError as exc:
         log.error(u'invalid query: {0}', exc)
         sys.exit(1)
     except IOError as exc:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -38,6 +38,7 @@ from beets.util.functemplate import Template
 from beets import config
 from beets.util import confit
 from beets.autotag import mb
+from beets.dbcore import query as db_query
 
 # On Windows platforms, use colorama to support "ANSI" terminal colors.
 if sys.platform == 'win32':
@@ -959,6 +960,9 @@ def main(args=None):
         sys.exit(1)
     except confit.ConfigError as exc:
         log.error(u'configuration error: {0}', exc)
+        sys.exit(1)
+    except db_query.InvalidQuery as exc:
+        log.error(u'invalid query: {0}', exc)
         sys.exit(1)
     except IOError as exc:
         if exc.errno == errno.EPIPE:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.11 (in development)
 -----------------------
 
+Features:
+
+* Stop on invalid queries instead of ignoring the invalid part.
+
 Fixes:
 
 * :doc:`/plugins/lyrics`: Silence a warning about insecure requests in the new

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -21,7 +21,7 @@ import helper
 import beets.library
 from beets import dbcore
 from beets.dbcore import types
-from beets.dbcore.query import NoneQuery, InvalidQuery
+from beets.dbcore.query import NoneQuery, InvalidQueryError
 from beets.library import Library, Item
 
 
@@ -276,11 +276,11 @@ class GetTest(DummyDataTestCase):
         self.assertFalse(results)
 
     def test_invalid_query(self):
-        with self.assertRaises(InvalidQuery) as raised:
+        with self.assertRaises(InvalidQueryError) as raised:
             dbcore.query.NumericQuery('year', '199a')
         self.assertIn('not an int', str(raised.exception))
 
-        with self.assertRaises(InvalidQuery) as raised:
+        with self.assertRaises(InvalidQueryError) as raised:
             dbcore.query.RegexpQuery('year', '199(')
         self.assertIn('not a regular expression', str(raised.exception))
         self.assertIn('unbalanced parenthesis', str(raised.exception))


### PR DESCRIPTION
So far an invalid query won't be applied:
`    $ beet ls The Beatles year:196a`
will be treaded as
`    $ beet ls The Beatles`
With this commit it stops beets, returns 1 and produces
`    $ invalid query: u'196a' is not an int or a float`
This applies to any querying and therefore on many command, plugins and
some configuration options.
Invalid queries exist on numeric fields and on regular expression usage.

Compile regular expression queries upon instantiation instead of upon
each match test.

The reporting can be improved (give more context). Fix #1219.