### PR TITLE
Update smartplaylist logging & unicode management

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -76,11 +76,10 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 items.extend(_items_for_query(lib, playlist['query'], False))
 
             m3us = {}
-            basename = playlist['name'].encode('utf8')
             # As we allow tags in the m3u names, we'll need to iterate through
             # the items and generate the correct m3u file names.
             for item in items:
-                m3u_name = item.evaluate_template(basename, True)
+                m3u_name = item.evaluate_template(playlist['name'], True)
                 if m3u_name not in m3us:
                     m3us[m3u_name] = []
                 item_path = item.path

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -67,7 +67,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             relative_to = normpath(relative_to)
 
         for playlist in playlists:
-            self._log.debug(u"Creating playlist {0.name}", playlist)
+            self._log.debug(u"Creating playlist {0[name]}", playlist)
             items = []
             if 'album_query' in playlist:
                 items.extend(_items_for_query(lib, playlist['album_query'],

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # This file is part of beets.
 # Copyright 2015, Adrian Sampson.
 #
@@ -14,6 +15,8 @@
 
 """Tests for template engine.
 """
+import warnings
+
 from _common import unittest
 from beets.util import functemplate
 
@@ -206,6 +209,13 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(len(arg_parts), 1)
         self._assert_call(arg_parts[0], u"bar", 1)
         self.assertEqual(list(_normexpr(arg_parts[0].args[0])), [u'baz'])
+
+    def test_fail_on_utf8(self):
+        parts = u'é'.encode('utf8')
+        warnings.simplefilter("ignore")
+        with self.assertRaises(UnicodeDecodeError):
+            functemplate._parse(parts)
+        warnings.simplefilter("default")
 
 
 class EvalTest(unittest.TestCase):


### PR DESCRIPTION
- Fix smartplaylist logging string
- Fix smartplaylist unicode playlist names management: don't use an utf8-encoded string as Template
- Add a test to Template: crash on utf8 string (enforce existing behaviour)