### PR TITLE
Make tracktotal an item-level field.

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -728,7 +728,6 @@ class Album(LibModel):
         'year':               types.PaddedInt(4),
         'month':              types.PaddedInt(2),
         'day':                types.PaddedInt(2),
-        'tracktotal':         types.PaddedInt(2),
         'disctotal':          types.PaddedInt(2),
         'comp':               types.BOOLEAN,
         'mb_albumid':         types.STRING,
@@ -767,7 +766,6 @@ class Album(LibModel):
         'year',
         'month',
         'day',
-        'tracktotal',
         'disctotal',
         'comp',
         'mb_albumid',
@@ -797,6 +795,7 @@ class Album(LibModel):
         # the album's directory as `path`.
         getters = plugins.album_field_getters()
         getters['path'] = Album.item_dir
+        getters['albumtotal'] = Album.tracktotal
         return getters
 
     def items(self):
@@ -883,6 +882,27 @@ class Album(LibModel):
         if not item:
             raise ValueError('empty album')
         return os.path.dirname(item.path)
+
+    def tracktotal(self):
+        """Return the total number of tracks on all discs on the album
+        """
+        if self.disctotal == 1 or not beets.config['per_disc_numbering']:
+            return self.items()[0].tracktotal
+
+        counted = []
+        total = 0
+
+        for item in self.items():
+            if item.disc in counted:
+                continue
+
+            total += item.tracktotal
+            counted.append(item.disc)
+
+            if len(counted) == self.disctotal:
+                break
+
+        return total
 
     def art_destination(self, image, item_dir=None):
         """Returns a path to the destination for the album art image

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -23,7 +23,7 @@ from beets.ui import decargs, print_obj, Subcommand
 def _missing_count(album):
     """Return number of missing items in `album`.
     """
-    return (album.tracktotal or 0) - len(album.items())
+    return (album.albumtotal or 0) - len(album.items())
 
 
 def _item(track_info, album_info, album_id):
@@ -139,7 +139,7 @@ class MissingPlugin(BeetsPlugin):
         """
         item_mbids = map(lambda x: x.mb_trackid, album.items())
 
-        if len([i for i in album.items()]) < album.tracktotal:
+        if len([i for i in album.items()]) < album.albumtotal:
             # fetch missing items
             # TODO: Implement caching that without breaking other stuff
             album_info = hooks.album_for_mbid(album.mb_albumid)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,21 @@ Features:
   search results you wish to see when looking up releases at MusicBrainz
   during import. :bug:`1245`
 
+Core improvements:
+
+* The ``tracktotal`` attribute is now a *track-level field* instead of an
+  album-level one. This field stores the total number of tracks on the
+  album, or if the ``per_disc_numbering`` config option is set, the total
+  number of tracks on a particular medium. With the latter option the
+  album-level incarnation of this field could not represent releases where
+  the total number of tracks differs per medium ---for example 20 tracks
+  on medium 1 and 21 tracks on medium 2. Now, tracktotal is correctly
+  handled also when ``per_disc_numbering`` is set.
+* Complimentary to the change for ``tracktotal`` there is now an album-level
+  ``albumtotal`` attribute. This field always provides the total numbers of
+  tracks on the album. The ``per_disc_numbering`` config option has no
+  influence on this field.
+
 Fixes:
 
 * :doc:`/plugins/lyrics`: Silence a warning about insecure requests in the new


### PR DESCRIPTION
This fixes tracktotal being stored incorrectly for multi-disc releases
where the individual discs have a different number of tracks and
per_disc_numbering is enabled.