### PR TITLE
mbsync: Support custom output format

### DIFF
--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -62,18 +62,19 @@ class MBSyncPlugin(BeetsPlugin):
         pretend = opts.pretend
         write = opts.write
         query = ui.decargs(args)
+        format = opts.format
 
-        self.template = Template(ui._pick_format(True, opts.format))
+        self.singletons(lib, query, move, pretend, write, format)
+        self.albums(lib, query, move, pretend, write, format)
 
-        self.singletons(lib, query, move, pretend, write)
-        self.albums(lib, query, move, pretend, write)
-
-    def singletons(self, lib, query, move, pretend, write):
+    def singletons(self, lib, query, move, pretend, write, format):
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
+        template = Template(ui._pick_format(False, format))
+
         for item in lib.items(query + ['singleton:true']):
-            item_formatted = item.evaluate_template(self.template)
+            item_formatted = item.evaluate_template(template)
             if not item.mb_trackid:
                 self._log.info(u'Skipping singleton with no mb_trackid: {0}',
                                item_formatted)
@@ -92,13 +93,15 @@ class MBSyncPlugin(BeetsPlugin):
                 autotag.apply_item_metadata(item, track_info)
                 apply_item_changes(lib, item, move, pretend, write)
 
-    def albums(self, lib, query, move, pretend, write):
+    def albums(self, lib, query, move, pretend, write, format):
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
         """
+        template = Template(ui._pick_format(True, format))
+
         # Process matching albums.
         for a in lib.albums(query):
-            album_formatted = a.evaluate_template(self.template)
+            album_formatted = a.evaluate_template(template)
             if not a.mb_albumid:
                 self._log.info(u'Skipping album with no mb_albumid: {0}',
                                album_formatted)

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -62,17 +62,18 @@ class MBSyncPlugin(BeetsPlugin):
         pretend = opts.pretend
         write = opts.write
         query = ui.decargs(args)
-        tmpl = Template(ui._pick_format(True, opts.format))
 
-        self.singletons(lib, query, move, pretend, write, tmpl)
-        self.albums(lib, query, move, pretend, write, tmpl)
+        self.template = Template(ui._pick_format(True, opts.format))
 
-    def singletons(self, lib, query, move, pretend, write, tmpl):
+        self.singletons(lib, query, move, pretend, write)
+        self.albums(lib, query, move, pretend, write)
+
+    def singletons(self, lib, query, move, pretend, write):
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
         for item in lib.items(query + ['singleton:true']):
-            item_formatted = item.evaluate_template(tmpl)
+            item_formatted = item.evaluate_template(self.template)
             if not item.mb_trackid:
                 self._log.info(u'Skipping singleton with no mb_trackid: {0}',
                                item_formatted)
@@ -91,13 +92,13 @@ class MBSyncPlugin(BeetsPlugin):
                 autotag.apply_item_metadata(item, track_info)
                 apply_item_changes(lib, item, move, pretend, write)
 
-    def albums(self, lib, query, move, pretend, write, tmpl):
+    def albums(self, lib, query, move, pretend, write):
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
         """
         # Process matching albums.
         for a in lib.albums(query):
-            album_formatted = a.evaluate_template(tmpl)
+            album_formatted = a.evaluate_template(self.template)
             if not a.mb_albumid:
                 self._log.info(u'Skipping album with no mb_albumid: {0}',
                                album_formatted)

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -62,16 +62,16 @@ class MBSyncPlugin(BeetsPlugin):
         pretend = opts.pretend
         write = opts.write
         query = ui.decargs(args)
-        format = opts.format
+        fmt = opts.format
 
-        self.singletons(lib, query, move, pretend, write, format)
-        self.albums(lib, query, move, pretend, write, format)
+        self.singletons(lib, query, move, pretend, write, fmt)
+        self.albums(lib, query, move, pretend, write, fmt)
 
-    def singletons(self, lib, query, move, pretend, write, format):
+    def singletons(self, lib, query, move, pretend, write, fmt):
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
-        template = Template(ui._pick_format(False, format))
+        template = Template(ui._pick_format(False, fmt))
 
         for item in lib.items(query + ['singleton:true']):
             item_formatted = item.evaluate_template(template)
@@ -93,11 +93,11 @@ class MBSyncPlugin(BeetsPlugin):
                 autotag.apply_item_metadata(item, track_info)
                 apply_item_changes(lib, item, move, pretend, write)
 
-    def albums(self, lib, query, move, pretend, write, format):
+    def albums(self, lib, query, move, pretend, write, fmt):
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
         """
-        template = Template(ui._pick_format(True, format))
+        template = Template(ui._pick_format(True, fmt))
 
         # Process matching albums.
         for a in lib.albums(query):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ Features:
 * :doc:`/plugins/web`: Add support for *cross-origin resource sharing* for
   more flexible in-browser clients. Thanks to Andre Miller. :bug:`1236`
   :bug:`1237`
+* :doc:`plugins/mbsync`: Add ``-f/--format`` option for controlling
+  the output format for unrecognized items.
 
 Fixes:
 

--- a/docs/plugins/mbsync.rst
+++ b/docs/plugins/mbsync.rst
@@ -33,3 +33,6 @@ The command has a few command-line options:
 * If you have the `import.write` configuration option enabled, then this
   plugin will write new metadata to files' tags. To disable this, use the
   ``-W`` (``--nowrite``) option.
+* To customize the output of unrecognized items, use the ``-f``
+  (``--format``) option. The default output is ``list_format_item`` or
+  ``list_format_album`` for items and albums, respectively.

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -68,15 +68,7 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
         album.load()
         self.assertEqual(album.album, 'album info')
 
-    @patch('beets.autotag.hooks.album_for_mbid')
-    @patch('beets.autotag.hooks.track_for_mbid')
-    def test_message_when_skipping(self, track_for_mbid, album_for_mbid):
-        album_for_mbid.return_value = \
-            generate_album_info('album id', ['track id'])
-        track_for_mbid.return_value = \
-            generate_track_info('singleton track id',
-                                {'title': 'singleton info'})
-
+    def test_message_when_skipping(self):
         # Test album with no mb_albumid.
         # The default format for an album include $albumartist so
         # set that here, too.

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -20,6 +20,7 @@ from helper import TestHelper,\
     generate_track_info, \
     capture_log
 
+from beets import config
 from beets.library import Item
 
 
@@ -69,6 +70,9 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
         self.assertEqual(album.album, 'album info')
 
     def test_message_when_skipping(self):
+        config['list_format_item'] = '$artist - $album - $title'
+        config['list_format_album'] = '$albumartist - $album'
+
         # Test album with no mb_albumid.
         # The default format for an album include $albumartist so
         # set that here, too.

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -43,11 +43,11 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
                                 {'title': 'singleton info'})
 
         # test album with no mb_albumid
-        album_invalid_item = Item(
+        album_invalid = Item(
             album='album info',
             path=''
         )
-        album_invalid = self.lib.add_album([album_invalid_item])
+        self.lib.add_album([album_invalid])
 
         with capture_log('beets.mbsync') as logs:
             self.run_command('mbsync', '-f', "'$album'")


### PR DESCRIPTION
The mbsync plugin doesn't have the most user-friendly output when dealing with unknown album releases. It only spits out beets' internal IDs or what seems to be a discogs(?) ID.

    $ beet mbsync -p
    Skipping album 410: has no mb_albumid
    Skipping album 333: has no mb_albumid
    Skipping album 1668: has no mb_albumid
    Skipping album 739: has no mb_albumid
    Skipping album 975: has no mb_albumid
    Skipping album 1189: has no mb_albumid
    Release ID not found: 6225814
    Release ID not found: 379309
    Skipping album 1669: has no mb_albumid
    Skipping album 198: has no mb_albumid

If we want to see what album this really is, another query is required:

    $ beet ls album_id:410

This commit adds a `-f/--format` option to allow custom output formats:

    $ beet mbsync -p -f '$album'
    Skipping album with no mb_albumid: Language Is For Everybody
    ...

It also changes the default output to match that of the `ls` command (it uses `ui._pick_format` to pick the correct default format for albums or items):

    $ beet mbsync -p
    Skipping album with no mb_albumid: Canada's Electric Tiger Machine - Language Is For Everybody