### PR TITLE
Replace print with _log.info() in CORS support

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -274,7 +274,8 @@ class WebPlugin(BeetsPlugin):
             app.config['lib'] = lib
             # Enable CORS if required.
             if self.config['cors']:
-                print "Enabling cors"
+                self._log.info(u'Enabling CORS with origin: {0}',
+                               self.config['cors'])
                 from flask.ext.cors import CORS
                 app.config['CORS_ALLOW_HEADERS'] = "Content-Type"
                 app.config['CORS_RESOURCES'] = {


### PR DESCRIPTION
Just a small cleanup - replacing print with _log.info() which now also shows the configured origin.