### PR TITLE
Fix bug where playlists were not created in subdirs.

### DIFF
--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -21,7 +21,7 @@ import os
 import re
 
 from beets.plugins import BeetsPlugin
-from beets.util import normpath, syspath, bytestring_path
+from beets.util import mkdirall, normpath, syspath, bytestring_path
 from beets import config
 
 M3U_DEFAULT_NAME = 'imported.m3u'
@@ -57,6 +57,7 @@ def _build_m3u_filename(basename):
 def _write_m3u(m3u_path, items_paths):
     """Append relative paths to items into m3u file.
     """
+    mkdirall(m3u_path)
     with open(syspath(m3u_path), 'a') as f:
         for path in items_paths:
             f.write(path + '\n')

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 from beets.plugins import BeetsPlugin
 from beets import ui
-from beets.util import normpath, syspath
+from beets.util import mkdirall, normpath, syspath
 import os
 
 
@@ -98,6 +98,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             # Now iterate through the m3us that we need to generate
             for m3u in m3us:
                 m3u_path = normpath(os.path.join(playlist_dir, m3u))
+                mkdirall(m3u_path)
                 with open(syspath(m3u_path), 'w') as f:
                     for path in m3us[m3u]:
                         f.write(path + '\n')

--- a/test/test_importfeeds.py
+++ b/test/test_importfeeds.py
@@ -37,6 +37,22 @@ class ImportfeedsTestTest(unittest.TestCase):
         with open(playlist_path) as playlist:
             self.assertIn(item_path, playlist.read())
 
+    def test_playlist_in_subdir(self):
+        config['importfeeds']['formats'] = 'm3u'
+        config['importfeeds']['m3u_name'] = 'subdir/imported.m3u'
+        album = Album(album='album/name', id=1)
+        item_path = os.path.join('path', 'to', 'item')
+        item = Item(title='song', album_id=1, path=item_path)
+        self.lib.add(album)
+        self.lib.add(item)
+
+        self.importfeeds.album_imported(self.lib, album)
+        playlist = os.path.join(self.feeds_dir,
+                                config['importfeeds']['m3u_name'].get())
+        playlist_subdir = os.path.dirname(playlist)
+        self.assertTrue(os.path.isdir(playlist_subdir))
+        self.assertTrue(os.path.isfile(playlist))
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
This PR fixes a minor bug where beets would crash if a playlist name contained a path separator and any parent directories didn't already exist. As far as I can see the only plugins affected are importfeeds and smartplaylists.

It may make more sense to eventually abstract the creation of new files and directories into a utility function so this type of bug isn't introduced again later (or maybe this already exists and I just missed it).

(Now if only mpd [supported playlists in subdirs](http://bugs.musicpd.org/view.php?id=311) I'd be all set!)