### PR TITLE
Display clear error message when MusicBrainz is unreachable

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -38,6 +38,8 @@ class MusicBrainzAPIError(util.HumanReadableException):
     """
     def __init__(self, reason, verb, query, tb=None):
         self.query = query
+        if isinstance(reason, musicbrainzngs.WebServiceError):
+            reason = 'MusicBrainz not reachable'
         super(MusicBrainzAPIError, self).__init__(reason, verb, tb)
 
     def get_message(self):
@@ -325,11 +327,6 @@ def match_album(artist, album, tracks=None):
     try:
         res = musicbrainzngs.search_releases(
             limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
-    except musicbrainzngs.WebServiceError:
-        log.debug(u'MusicBrainz is unreachable.')
-        raise MusicBrainzAPIError('MusicBrainz not reachable',
-                                  'release search', criteria,
-                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'release search', criteria,
                                   traceback.format_exc())
@@ -356,11 +353,6 @@ def match_track(artist, title):
     try:
         res = musicbrainzngs.search_recordings(
             limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
-    except musicbrainzngs.WebServiceError:
-        log.debug(u'MusicBrainz is unreachable.')
-        raise MusicBrainzAPIError('MusicBrainz not reachable',
-                                  'recording search', criteria,
-                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'recording search', criteria,
                                   traceback.format_exc())
@@ -393,11 +385,6 @@ def album_for_id(releaseid):
     except musicbrainzngs.ResponseError:
         log.debug(u'Album ID match failed.')
         return None
-    except musicbrainzngs.WebServiceError:
-        log.debug(u'MusicBrainz is unreachable.')
-        raise MusicBrainzAPIError('MusicBrainz not reachable',
-                                  'get release by ID', albumid,
-                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get release by ID', albumid,
                                   traceback.format_exc())
@@ -417,11 +404,6 @@ def track_for_id(releaseid):
     except musicbrainzngs.ResponseError:
         log.debug(u'Track ID match failed.')
         return None
-    except musicbrainzngs.WebServiceError:
-        log.debug(u'MusicBrainz is unreachable.')
-        raise MusicBrainzAPIError('MusicBrainz not reachable',
-                                  'get recording by ID', trackid,
-                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get recording by ID', trackid,
                                   traceback.format_exc())

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -325,6 +325,11 @@ def match_album(artist, album, tracks=None):
     try:
         res = musicbrainzngs.search_releases(
             limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
+    except musicbrainzngs.WebServiceError:
+        log.debug(u'MusicBrainz is unreachable.')
+        raise MusicBrainzAPIError('MusicBrainz not reachable',
+                                  'release search', criteria,
+                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'release search', criteria,
                                   traceback.format_exc())
@@ -351,6 +356,11 @@ def match_track(artist, title):
     try:
         res = musicbrainzngs.search_recordings(
             limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
+    except musicbrainzngs.WebServiceError:
+        log.debug(u'MusicBrainz is unreachable.')
+        raise MusicBrainzAPIError('MusicBrainz not reachable',
+                                  'recording search', criteria,
+                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'recording search', criteria,
                                   traceback.format_exc())
@@ -383,6 +393,11 @@ def album_for_id(releaseid):
     except musicbrainzngs.ResponseError:
         log.debug(u'Album ID match failed.')
         return None
+    except musicbrainzngs.WebServiceError:
+        log.debug(u'MusicBrainz is unreachable.')
+        raise MusicBrainzAPIError('MusicBrainz not reachable',
+                                  'get release by ID', albumid,
+                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get release by ID', albumid,
                                   traceback.format_exc())
@@ -402,6 +417,11 @@ def track_for_id(releaseid):
     except musicbrainzngs.ResponseError:
         log.debug(u'Track ID match failed.')
         return None
+    except musicbrainzngs.WebServiceError:
+        log.debug(u'MusicBrainz is unreachable.')
+        raise MusicBrainzAPIError('MusicBrainz not reachable',
+                                  'get recording by ID', trackid,
+                                  traceback.format_exc())
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get recording by ID', trackid,
                                   traceback.format_exc())


### PR DESCRIPTION
E.g.:  `Error: MusicBrainz not reachable in get release by ID with query etc etc ...`

Catch musicbrainzngs.WebServiceError before the general musicbrainzngs.MusicBrainzError
Fix #1190