### PR TITLE
Allow plugins to change the created import tasks

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -556,11 +556,8 @@ class ImportTask(object):
         if not tasks:
             tasks = [self]
         else:
-            # The plugins gave us a list of lists of task. Flatten it.
-            flat_tasks = []
-            for inner in tasks:
-                flat_tasks += inner
-            tasks = [t for t in flat_tasks if t]
+            # The plugins gave us a list of lists of tasks. Flatten it.
+            tasks = [t for inner in tasks for t in inner]
         return tasks
 
     def lookup_candidates(self):

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -18,7 +18,7 @@
 import re
 from beets import config
 from beets.plugins import BeetsPlugin
-from beets.importer import action, SingletonImportTask
+from beets.importer import SingletonImportTask
 
 
 class FileFilterPlugin(BeetsPlugin):
@@ -50,10 +50,11 @@ class FileFilterPlugin(BeetsPlugin):
             if len(items_to_import) > 0:
                 task.items = items_to_import
             else:
-                task.choice_flag = action.SKIP
+                return []
         elif isinstance(task, SingletonImportTask):
             if not self.file_filter(task.item['path']):
-                task.choice_flag = action.SKIP
+                return []
+        return [task]
 
     def file_filter(self, full_path):
         """Checks if the configured regular expressions allow the import

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,7 +96,8 @@ For developers:
   should!) use modern ``{}``-style string formatting lazily. See
   :ref:`plugin-logging` in the plugin API docs.
 * A new ``import_task_created`` event lets you manipulate import tasks
-  immediately after they are initialized.
+  immediately after they are initialized. It's also possible to replace the
+  originally created tasks by returning new ones using this event.
 
 
 1.3.10 (January 5, 2015)

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -175,9 +175,11 @@ The events currently available are:
   written to disk (i.e., just after the file on disk is closed).
 
 * *import_task_created*: called immediately after an import task is
-  initialized. Plugins can use this to, for example, cancel processing of a
-  task before anything else happens. ``task`` (an `ImportTask`) and
-  ``session`` (an `ImportSession`).
+  initialized. Plugins can use this to, for example, change imported files of a
+  task before anything else happens. It's also possible to replace the task
+  with another task by returning a list of tasks. This list can contain zero
+  or more `ImportTask`s. Returning an empty list will stop the task.
+  Parameters: ``task`` (an `ImportTask`) and ``session`` (an `ImportSession`).
 
 * *import_task_start*: called when before an import task begins processing.
   Parameters: ``task`` and ``session``.

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -243,9 +243,8 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
 
         logs = [line for line in logs if not line.startswith('Sending event:')]
         self.assertEqual(logs, [
-            'Album: {0}/album'.format(self.import_dir),
-            '  {0}'.format(self.file_paths[0]),
-            '  {0}'.format(self.file_paths[1]),
+            'Singleton: {0}'.format(self.file_paths[0]),
+            'Singleton: {0}'.format(self.file_paths[1]),
         ])
 
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -207,6 +207,26 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
             self.file_paths.append(dest_path)
 
     def test_import_task_created(self):
+        import_files = [self.import_dir]
+        self._setup_import_session(singletons=False)
+        self.importer.paths = import_files
+
+        with helper.capture_log() as logs:
+            self.importer.run()
+        self.unload_plugins()
+
+        # Exactly one event should have been imported (for the album).
+        # Sentinels do not get emitted.
+        self.assertEqual(logs.count('Sending event: import_task_created'), 1)
+
+        logs = [line for line in logs if not line.startswith('Sending event:')]
+        self.assertEqual(logs, [
+            'Album: {0}'.format(os.path.join(self.import_dir, 'album')),
+            '  {0}'.format(self.file_paths[0]),
+            '  {0}'.format(self.file_paths[1]),
+        ])
+
+    def test_import_task_created_with_plugin(self):
         class ToSingletonPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(ToSingletonPlugin, self).__init__()


### PR DESCRIPTION
This is a new approach to get #1167 done. With the things done with #1186, this is a very simple process :smile:.
At all places where `emit_created` is called, I made sure that the returned list of tasks is used instead of the original task.