### PR TITLE
Extend item.write() to embed images without changing item

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -148,13 +148,11 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
         try:
             self._log.debug(u'embedding {0}', displayable_path(imagepath))
-            item['images'] = [self._mediafile_image(imagepath, maxwidth)]
+            image = self._mediafile_image(imagepath, maxwidth)
         except IOError as exc:
             self._log.warning(u'could not read image file: {0}', exc)
-        else:
-            # We don't want to store the image in the database.
-            item.try_write(itempath)
-            del item['images']
+            return
+        item.try_write(path=itempath, tags={'images': [image]})
 
     def embed_album(self, album, maxwidth=None, quiet=False):
         """Embed album art into all of the album's items.

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -35,6 +35,7 @@ from beets import util
 from beets import plugins
 from beets import config
 from beets.mediafile import MediaFile
+from test.helper import TestHelper
 
 # Shortcut to path normalization.
 np = util.normpath
@@ -1109,37 +1110,49 @@ class UnicodePathTest(_common.LibTestCase):
         self.i.write()
 
 
-class WriteTest(_common.LibTestCase):
+class WriteTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_beets()
+
+    def tearDown(self):
+        self.teardown_beets()
+
     def test_write_nonexistant(self):
-        self.i.path = '/path/does/not/exist'
-        self.assertRaises(beets.library.ReadError, self.i.write)
+        item = self.create_item()
+        item.path = '/path/does/not/exist'
+        with self.assertRaises(beets.library.ReadError):
+            item.write()
 
     def test_no_write_permission(self):
-        path = os.path.join(self.temp_dir, 'file.mp3')
-        shutil.copy(os.path.join(_common.RSRC, 'empty.mp3'), path)
+        item = self.add_item_fixture()
+        path = item.path
         os.chmod(path, stat.S_IRUSR)
 
         try:
-            self.i.path = path
-            self.assertRaises(beets.library.WriteError, self.i.write)
+            self.assertRaises(beets.library.WriteError, item.write)
 
         finally:
             # Restore write permissions so the file can be cleaned up.
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
 
     def test_write_with_custom_path(self):
-        custom_path = os.path.join(self.temp_dir, 'file.mp3')
-        self.i.path = os.path.join(self.temp_dir, 'item_file.mp3')
-        shutil.copy(os.path.join(_common.RSRC, 'empty.mp3'), custom_path)
-        shutil.copy(os.path.join(_common.RSRC, 'empty.mp3'), self.i.path)
+        item = self.add_item_fixture()
+        custom_path = os.path.join(self.temp_dir, 'custom.mp3')
+        shutil.copy(item.path, custom_path)
 
-        self.i['artist'] = 'new artist'
+        item['artist'] = 'new artist'
         self.assertNotEqual(MediaFile(custom_path).artist, 'new artist')
-        self.assertNotEqual(MediaFile(self.i.path).artist, 'new artist')
+        self.assertNotEqual(MediaFile(item.path).artist, 'new artist')
 
-        self.i.write(custom_path)
+        item.write(custom_path)
         self.assertEqual(MediaFile(custom_path).artist, 'new artist')
-        self.assertNotEqual(MediaFile(self.i.path).artist, 'new artist')
+        self.assertNotEqual(MediaFile(item.path).artist, 'new artist')
+
+    def test_write_custom_tags(self):
+        item = self.add_item_fixture(artist='old artist')
+        item.write(tags={'artist': 'new artist'})
+        self.assertNotEqual(item.artist, 'new artist')
+        self.assertEqual(MediaFile(item.path).artist, 'new artist')
 
 
 class ItemReadTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #1241 and geigerzaehler/beets-check#14

Before, `embed_item` would add the images to the item and then call `item.write()` to write the item data, including the image, to the file. This would trigger `item.store()` in the `after_write` hook of the check plugin. This would in turn try to persist the temporary `images` attribute of the item, resulting in an SQL error.