### PR TITLE
Stop applying mp3gain directly to files. Fixes #1316

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -179,7 +179,6 @@ class CommandBackend(Backend):
         else:
             # Disable clipping warning.
             cmd = cmd + ['-c']
-        cmd = cmd + ['-a' if is_album else '-r']
         cmd = cmd + ['-d', bytes(self.gain_offset)]
         cmd = cmd + [syspath(i.path) for i in items]
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,8 @@ Core changes:
 
 Fixes:
 
+* :doc:`/plugins/replaygain`: Stop applying replaygain directly to source files
+  when using the mp3gain backend. :bug:`1316`
 * :doc:`/plugins/lyrics`: Silence a warning about insecure requests in the new
   MusixMatch backend. :bug:`1204`
 * Fix a crash when ``beet`` is invoked without arguments. :bug:`1205`

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -92,11 +92,6 @@ configuration file. The available options are:
 
 These options only work with the "command" backend:
 
-- **apply**: If you use a player that does not support ReplayGain
-  specifications, you can force the volume normalization by applying the gain
-  to the file via the ``apply`` option. This is a lossless and reversible
-  operation with no transcoding involved.
-  Default: ``no``.
 - **command**: The path to the ``mp3gain`` or ``aacgain`` executable (if beets
   cannot find it by itself).
   For example: ``/Applications/MacMP3Gain.app/Contents/Resources/aacgain``.


### PR DESCRIPTION
Update docs to remove non-existent `apply` option.