### PR TITLE
Delete 'format' variables that shadow the built-in

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1296,11 +1296,11 @@ class DefaultTemplateFunctions(object):
         return unidecode(s)
 
     @staticmethod
-    def tmpl_time(s, format):
+    def tmpl_time(s, fmt):
         """Format a time value using `strftime`.
         """
         cur_fmt = beets.config['time_format'].get(unicode)
-        return time.strftime(format, time.strptime(s, cur_fmt))
+        return time.strftime(fmt, time.strptime(s, cur_fmt))
 
     def tmpl_aunique(self, keys=None, disam=None):
         """Generate a string that is guaranteed to be unique among all

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -438,8 +438,8 @@ def summarize_items(items, singleton):
         summary_parts.append(items[0].format)
     else:
         # Enumerate all the formats.
-        for format, count in format_counts.iteritems():
-            summary_parts.append('{0} {1}'.format(format, count))
+        for fmt, count in format_counts.iteritems():
+            summary_parts.append('{0} {1}'.format(fmt, count))
 
     average_bitrate = sum([item.bitrate for item in items]) / len(items)
     total_duration = sum([item.length for item in items])

--- a/beetsplug/the.py
+++ b/beetsplug/the.py
@@ -30,12 +30,6 @@ FORMAT = u'{0}, {1}'
 
 class ThePlugin(BeetsPlugin):
 
-    _instance = None
-
-    the = True
-    a = True
-    format = u''
-    strip = False
     patterns = []
 
     def __init__(self):

--- a/test/test_the.py
+++ b/test/test_the.py
@@ -44,7 +44,6 @@ class ThePluginTest(_common.TestCase):
 
     def test_template_function_with_defaults(self):
         ThePlugin().patterns = [PATTERN_THE, PATTERN_A]
-        ThePlugin().format = FORMAT
         self.assertEqual(ThePlugin().the_template_func('The The'), 'The, The')
         self.assertEqual(ThePlugin().the_template_func('An A'), 'A, An')
 


### PR DESCRIPTION
Also cleanup the 'the' plugin a bit: delete unused variables.

Relates to #1300.