### PR TITLE
Fix a crash when extracting album art

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -26,7 +26,7 @@ from beets.plugins import BeetsPlugin
 from beets import mediafile
 from beets import ui
 from beets.ui import decargs
-from beets.util import syspath, normpath, displayable_path
+from beets.util import syspath, normpath, displayable_path, bytestring_path
 from beets.util.artresizer import ArtResizer
 from beets import config
 
@@ -101,14 +101,14 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 self.extract_first(normpath(opts.outpath),
                                    lib.items(decargs(args)))
             else:
-                filename = opts.filename or config['art_filename'].get()
+                filename = bytestring_path(opts.filename or
+                                           config['art_filename'].get())
                 if os.path.dirname(filename) != '':
                     self._log.error(u"Only specify a name rather than a path "
                                     u"for -n")
                     return
                 for album in lib.albums(decargs(args)):
-                    albumpath = album.path.decode('utf-8')
-                    artpath = normpath(os.path.join(albumpath, filename))
+                    artpath = normpath(os.path.join(album.path, filename))
                     artpath = self.extract_first(artpath, album.items())
                     if artpath and opts.associate:
                         album.set_art(artpath)
@@ -266,7 +266,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             self._log.warning(u'Unknown image type in {0}.',
                               displayable_path(item.path))
             return
-        outpath = outpath.decode('utf-8') + '.' + ext
+        outpath = outpath + b'.' + ext
 
         self._log.info(u'Extracting album art from: {0} to: {1}',
                        item, displayable_path(outpath))

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -107,7 +107,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                     u"for -n")
                     return
                 for album in lib.albums(decargs(args)):
-                    artpath = normpath(os.path.join(album.path, filename))
+                    albumpath = album.path.decode('utf-8')
+                    artpath = normpath(os.path.join(albumpath, filename))
                     artpath = self.extract_first(artpath, album.items())
                     if artpath and opts.associate:
                         album.set_art(artpath)
@@ -265,7 +266,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             self._log.warning(u'Unknown image type in {0}.',
                               displayable_path(item.path))
             return
-        outpath += '.' + ext
+        outpath = outpath.decode('utf-8') + '.' + ext
 
         self._log.info(u'Extracting album art from: {0} to: {1}',
                        item, displayable_path(outpath))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -101,8 +101,6 @@ Fixes:
   Unicode filenames. :bug:`1297`
 * :doc:`/plugins/discogs`: Handle and log more kinds of communication
   errors. :bug:`1299` :bug:`1305`
-* :doc:`/plugins/embedart`: Fix a crash that occured when the album path
-  contains non ascii characters.
 
 For developers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -101,6 +101,8 @@ Fixes:
   Unicode filenames. :bug:`1297`
 * :doc:`/plugins/discogs`: Handle and log more kinds of communication
   errors. :bug:`1299` :bug:`1305`
+* :doc:`/plugins/embedart`: Fix a crash that occured when the album path
+  contains non ascii characters.
 
 For developers:
 

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -16,6 +16,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 import os.path
+import shutil
 from mock import Mock, patch
 
 from test import _common
@@ -41,7 +42,7 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(unittest.TestCase, TestHelper):
+class EmbedartCliTest(_common.TestCase, TestHelper):
 
     small_artpath = os.path.join(_common.RSRC, 'image-2x3.jpg')
     abbey_artpath = os.path.join(_common.RSRC, 'abbey.jpg')
@@ -113,6 +114,19 @@ class EmbedartCliTest(unittest.TestCase, TestHelper):
         self.assertEqual(mediafile.images[0].data, self.image_data,
                          'Image written is not {0}'.format(
                          self.abbey_similarpath))
+
+    def test_non_ascii_album_path(self):
+        import_dir = os.path.join(self.temp_dir, 'testsrcdir\xe4')
+        resource_path = os.path.join(_common.RSRC, 'image.mp3')
+        album = self.add_album_fixture()
+        trackpath = album.items()[0].path
+        albumpath = album.path
+        shutil.copy(resource_path, trackpath.decode('utf-8'))
+
+        self.run_command('extractart', '-n', 'extracted')
+
+        self.assertExists(os.path.join(albumpath.decode('utf-8'),
+                                       'extracted.png'))
 
 
 class EmbedartTest(unittest.TestCase):

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -116,7 +116,6 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
                          self.abbey_similarpath))
 
     def test_non_ascii_album_path(self):
-        import_dir = os.path.join(self.temp_dir, 'testsrcdir\xe4')
         resource_path = os.path.join(_common.RSRC, 'image.mp3')
         album = self.add_album_fixture()
         trackpath = album.items()[0].path


### PR DESCRIPTION
The crash happened when the album path contains non ascii characters (like äöü). I'm not sure if the solution I implemented is the best way to get around this...