### PR TITLE
Fix path query case sensitivity

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -37,7 +37,13 @@ class InvalidQueryError(ParsingError):
     def __init__(self, query, explanation):
         if isinstance(query, list):
             query = " ".join(query)
-        message = "'{0}': {1}".format(query, explanation)
+        try:
+            message = "'{0}': {1}".format(query, explanation)
+        except UnicodeDecodeError:
+            # queries are unicode. however if for an unholy reason it's not
+            # the case, an InvalidQueryError may be raised -- and report it
+            # correctly than fail again here
+            message = "{0!r}: {1}".format(query, explanation)
         super(InvalidQueryError, self).__init__(message)
 
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -37,13 +37,7 @@ class InvalidQueryError(ParsingError):
     def __init__(self, query, explanation):
         if isinstance(query, list):
             query = " ".join(query)
-        try:
-            message = "'{0}': {1}".format(query, explanation)
-        except UnicodeDecodeError:
-            # queries are unicode. however if for an unholy reason it's not
-            # the case, an InvalidQueryError may be raised -- and report it
-            # correctly than fail again here
-            message = "{0!r}: {1}".format(query, explanation)
+        message = "'{0}': {1}".format(query, explanation)
         super(InvalidQueryError, self).__init__(message)
 
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -73,8 +73,8 @@ class PathQuery(dbcore.FieldQuery):
 
         if not self._is_windows:
             dir_blob = buffer(self.dir_path)
-            return '({0} = ?) || (instr({0}, ?) = 1)'.format(self.field), \
-                   (file_blob, dir_blob)
+            return '({0} = ?) || (substr({0}, 1, ?) = ?)'.format(self.field), \
+                   (file_blob, len(dir_blob), dir_blob)
 
         escape = lambda m: self.escape_char + m.group(0)
         dir_pattern = self.escape_re.sub(escape, self.dir_path)

--- a/beets/library.py
+++ b/beets/library.py
@@ -1107,11 +1107,12 @@ def parse_query_string(s, model_cls):
 
     The string is split into components using shell-like syntax.
     """
+    assert isinstance(s, unicode), "Query is not unicode: {0!r}".format(s)
+
     # A bug in Python < 2.7.3 prevents correct shlex splitting of
     # Unicode strings.
     # http://bugs.python.org/issue6988
-    if isinstance(s, unicode):
-        s = s.encode('utf8')
+    s = s.encode('utf8')
     try:
         parts = [p.decode('utf8') for p in shlex.split(s)]
     except ValueError as exc:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,7 @@ Core changes:
 
 Fixes:
 
+* Path queries are case-sensitive on UNIX OSes. :bug:`1165`
 * :doc:`/plugins/lyrics`: Silence a warning about insecure requests in the new
   MusixMatch backend. :bug:`1204`
 * Fix a crash when ``beet`` is invoked without arguments. :bug:`1205`

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -184,6 +184,8 @@ Note that this only matches items that are *already in your library*, so a path
 query won't necessarily find *all* the audio files in a directory---just the
 ones you've already added to your beets library.
 
+Such queries are case-sensitive on UNIX and case-insensitive on Microsoft
+Windows.
 
 .. _query-sort:
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1195,6 +1195,13 @@ class ParseQueryTest(unittest.TestCase):
         self.assertIsInstance(raised.exception,
                               beets.dbcore.query.ParsingError)
 
+    def test_parse_byte_string(self):
+        with self.assertRaises(beets.dbcore.InvalidQueryError) as raised:
+            beets.library.parse_query_string(b'f\xf2o', None)
+        self.assertIn("can't decode", unicode(raised.exception))
+        self.assertIsInstance(raised.exception,
+                              beets.dbcore.query.ParsingError)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1195,13 +1195,6 @@ class ParseQueryTest(unittest.TestCase):
         self.assertIsInstance(raised.exception,
                               beets.dbcore.query.ParsingError)
 
-    def test_parse_byte_string(self):
-        with self.assertRaises(beets.dbcore.InvalidQueryError) as raised:
-            beets.library.parse_query_string(b'f\xf2o', None)
-        self.assertIn("can't decode", unicode(raised.exception))
-        self.assertIsInstance(raised.exception,
-                              beets.dbcore.query.ParsingError)
-
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1195,6 +1195,10 @@ class ParseQueryTest(unittest.TestCase):
         self.assertIsInstance(raised.exception,
                               beets.dbcore.query.ParsingError)
 
+    def test_parse_bytes(self):
+        with self.assertRaises(AssertionError):
+            beets.library.parse_query_string(b"query", None)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -474,6 +474,12 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
             results = self.lib.items(q)
             self.assert_items_matched(results, ['path item', 'caps path'])
 
+    def test_utf8_bytes(self):
+        self.add_album(path=b'/\xc3\xa0/b/c.mp3', title='latin byte')
+        q = b'path:/\xc3\xa0/b/c.mp3'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['latin byte'])
+
 
 class IntQueryTest(unittest.TestCase, TestHelper):
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -465,7 +465,7 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
 
     def test_case_sensitivity(self):
         self.add_album(path='/A/B/C2.mp3', title='caps path')
-        q = b'path:/A/B'
+        q = 'path:/A/B'
         with patch('beets.library.PathQuery._is_windows', False):
             results = self.lib.items(q)
             self.assert_items_matched(results, ['caps path'])
@@ -473,12 +473,6 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         with patch('beets.library.PathQuery._is_windows', True):
             results = self.lib.items(q)
             self.assert_items_matched(results, ['path item', 'caps path'])
-
-    def test_utf8_bytes(self):
-        self.add_album(path=b'/\xc3\xa0/b/c.mp3', title='latin byte')
-        q = b'path:/\xc3\xa0/b/c.mp3'
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ['latin byte'])
 
 
 class IntQueryTest(unittest.TestCase, TestHelper):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -17,6 +17,8 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
+from mock import patch
+
 from test import _common
 from test._common import unittest
 from test import helper
@@ -460,6 +462,17 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
 
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ['album with backslash'])
+
+    def test_case_sensitivity(self):
+        self.add_album(path='/A/B/C2.mp3', title='caps path')
+        q = b'path:/A/B'
+        with patch('beets.library.PathQuery._is_windows', False):
+            results = self.lib.items(q)
+            self.assert_items_matched(results, ['caps path'])
+
+        with patch('beets.library.PathQuery._is_windows', True):
+            results = self.lib.items(q)
+            self.assert_items_matched(results, ['path item', 'caps path'])
 
 
 class IntQueryTest(unittest.TestCase, TestHelper):


### PR DESCRIPTION
PathQuery uses LIKE on Windows and instr() = 1 on UNIX.

Fix #1165.