### PR TITLE
Improve art detection

### DIFF
--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -124,11 +124,8 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
 
         self.run_command('extractart', '-n', 'extracted')
 
-        path = os.path.join(albumpath.decode('utf-8'), 'extracted.')
-        found = any(map(lambda ext: os.path.exists(path + ext),
-                        ['png', 'jpeg', 'jpg']))
-
-        self.assertTrue(found, 'Extracted image was not found!')
+        self.assertExists(os.path.join(albumpath.decode('utf-8'),
+                                       'extracted.png'))
 
 
 class EmbedartTest(unittest.TestCase):

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -662,7 +662,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
                 errors.append('Tag %s does not exist' % key)
             else:
                 if value2 != value:
-                    errors.append('Tag %s: %s != %s' % (key, value2, value))
+                    errors.append('Tag %s: %r != %r' % (key, value2, value))
         if any(errors):
             errors = ['Tags did not match'] + errors
             self.fail('\n  '.join(errors))

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -28,7 +28,7 @@ from test import _common
 from test._common import unittest
 from beets.mediafile import MediaFile, MediaField, Image, \
     MP3DescStorageStyle, StorageStyle, MP4StorageStyle, \
-    ASFStorageStyle, ImageType
+    ASFStorageStyle, ImageType, CoverArtField
 from beets.library import Item
 from beets.plugins import BeetsPlugin
 
@@ -160,6 +160,13 @@ class ImageStructureTestMixin(ArtTestMixin):
 
         mediafile = MediaFile(mediafile.path)
         self.assertEqual(len(mediafile.images), 0)
+
+    def test_guess_cover(self):
+        mediafile = self._mediafile_fixture('image')
+        self.assertEqual(len(mediafile.images), 2)
+        cover = CoverArtField.guess_cover_image(mediafile.images)
+        self.assertEqual(cover.desc, 'album cover')
+        self.assertEqual(mediafile.art, cover.data)
 
     def assertExtendedImageAttributes(self, image, **kwargs):
         """Ignore extended image attributes in the base tests.
@@ -757,6 +764,10 @@ class MP4Test(ReadWriteTestBase, PartialTestMixin,
         mediafile = self._mediafile_fixture('empty')
         with self.assertRaises(ValueError):
             mediafile.images = [Image(data=self.tiff_data)]
+
+    def test_guess_cover(self):
+        # There is no metadata associated with images, we pick one at random
+        pass
 
 
 class AlacTest(ReadWriteTestBase, unittest.TestCase):


### PR DESCRIPTION
Filter images on their type, looking for `ImageType.front` ones.

Fix #1332.