### PR TITLE
Added support for bs1770gain, a loudness-scanner

### DIFF
--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -139,7 +139,7 @@ class ScrubPlugin(BeetsPlugin):
                 self._log.error(u'could not scrub {0}: {1}',
                                 util.displayable_path(path), exc)
 
-    def write_item(self, path):
+    def write_item(self, item, path, tags):
         """Automatically embed art into imported albums."""
         if not scrubbing and self.config['auto']:
             self._log.debug(u'auto-scrubbing {0}', util.displayable_path(path))

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -452,6 +452,22 @@ class DestinationTest(_common.TestCase):
         self.assertEqual(self.i.destination(),
                          np('base/one/_.mp3'))
 
+    @unittest.skip('unimplemented: #496')
+    def test_truncation_does_not_conflict_with_replacement(self):
+        # Use a replacement that should always replace the last X in any
+        # path component with a Z.
+        self.lib.replacements = [
+            (re.compile(r'X$'), u'Z'),
+        ]
+
+        # Construct an item whose untruncated path ends with a Y but whose
+        # truncated version ends with an X.
+        self.i.title = 'X' * 300 + 'Y'
+
+        # The final path should reflect the replacement.
+        dest = self.i.destination()
+        self.assertTrue('XZ' in dest)
+
 
 class ItemFormattedMappingTest(_common.LibTestCase):
     def test_formatted_item_value(self):


### PR DESCRIPTION
New to this... 
I have added support  for bs1770gain (http://bs1770gain.sourceforge.net). 
Just download it (   ex. http://download2.polytechnic.edu.na/pub/sourceforge/b/bs/bs1770gain/bs1770gain/0.4.1/
 ) and put it in your $PATH. 
In beets.config under replaygain: I put
backend: bs1770gain
method: --replaygain

I am running it for a few days,  it works. 
Instead of --replaygain you can use... 
 --ebu:  calculate replay gain according to EBU R128
   (-23.0 LUFS, default)
 --atsc:  calculate replay gain according to ATSC A/85
   (-24.0 LUFS)
 --replaygain:  calculate replay gain according to
   ReplayGain 2.0 (-18.0 LUFS)

If you wonder what loudness is all about... https://auphonic.com/blog/2012/08/02/loudness-measurement-and-normalization-ebu-r128-calm-act/

I was wondering if I should put a reference level tag with it.  Might come in very handy for searching and re-replaygaining your library.  The ref level is what's between the brackets (ex. -18.0 LUFS) and is dependent on the chosen method... but I wonder what would be an easy way to implement that. Now it has just this album gain/track gain standard...
Any help/ suggestions/remarks.... They are all appreciated... 