### PR TITLE
Add debug log for plugin paths

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -921,6 +921,7 @@ def _load_plugins(config):
     """
     paths = config['pluginpath'].get(confit.StrSeq(split=False))
     paths = map(util.normpath, paths)
+    log.debug('plugin paths: {0}', util.displayable_path(paths))
 
     import beetsplug
     beetsplug.__path__ = paths + beetsplug.__path__


### PR DESCRIPTION
I needed this info when creating a plugin.

By the way, do you prefer small PRs like this one? Or more consequent ones (e.g. some more debug logs could be added, maybe better if I propose a bigger PR?)