### PR TITLE
ui.commands.summarize_items(): don't crash when there is no item

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -437,8 +437,9 @@ def summarize_items(items, singleton):
         # A single format.
         summary_parts.append(items[0].format)
     else:
-        # Enumerate all the formats.
-        for fmt, count in format_counts.iteritems():
+        # Enumerate all the formats by decreasing frequencies:
+        for fmt, count in sorted(format_counts.items(),
+                                 key=lambda (f, c): (-c, f)):
             summary_parts.append('{0} {1}'.format(fmt, count))
 
     if items:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -426,8 +426,6 @@ def summarize_items(items, singleton):
     this is an album or single-item import (if the latter, them `items`
     should only have one element).
     """
-    assert items, "summarizing zero items"
-
     summary_parts = []
     if not singleton:
         summary_parts.append("{0} items".format(len(items)))
@@ -443,12 +441,13 @@ def summarize_items(items, singleton):
         for fmt, count in format_counts.iteritems():
             summary_parts.append('{0} {1}'.format(fmt, count))
 
-    average_bitrate = sum([item.bitrate for item in items]) / len(items)
-    total_duration = sum([item.length for item in items])
-    total_filesize = sum([item.filesize for item in items])
-    summary_parts.append('{0}kbps'.format(int(average_bitrate / 1000)))
-    summary_parts.append(ui.human_seconds_short(total_duration))
-    summary_parts.append(ui.human_bytes(total_filesize))
+    if items:
+        average_bitrate = sum([item.bitrate for item in items]) / len(items)
+        total_duration = sum([item.length for item in items])
+        total_filesize = sum([item.filesize for item in items])
+        summary_parts.append('{0}kbps'.format(int(average_bitrate / 1000)))
+        summary_parts.append(ui.human_seconds_short(total_duration))
+        summary_parts.append(ui.human_bytes(total_filesize))
 
     return ', '.join(summary_parts)
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1005,7 +1005,10 @@ class SummarizeItemsTest(_common.TestCase):
 
         i2.format = "G"
         summary = commands.summarize_items([self.item, i2], False)
-        self.assertEqual(summary, "2 items, G 1, F 1, 4kbps, 21:48, 1.9 KB")
+        self.assertEqual(summary, "2 items, F 1, G 1, 4kbps, 21:48, 1.9 KB")
+
+        summary = commands.summarize_items([self.item, i2, i2], False)
+        self.assertEqual(summary, "3 items, G 2, F 1, 4kbps, 32:42, 2.9 KB")
 
 
 class PathFormatTest(_common.TestCase):


### PR DESCRIPTION
Make `summarize_items()` correctly handle empty item lists, which happen on empty albums.
I also added some tests: `test.test_ui.SummarizeItemsTest`.
This fixes #1357.