### PR TITLE
Smartplaylist only updates playlists that may have changed

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -697,7 +697,7 @@ class MultipleSort(Sort):
 
     def __eq__(self, other):
         return super(MultipleSort, self).__eq__(other) and \
-               self.sorts == other.sorts
+            self.sorts == other.sorts
 
 
 class FieldSort(Sort):
@@ -727,8 +727,8 @@ class FieldSort(Sort):
 
     def __eq__(self, other):
         return super(FieldSort, self).__eq__(other) and \
-               self.field == other.field and \
-               self.ascending == other.ascending
+            self.field == other.field and \
+            self.ascending == other.ascending
 
 
 class FixedFieldSort(FieldSort):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -73,6 +73,9 @@ class Query(object):
         """
         raise NotImplementedError
 
+    def __eq__(self, other):
+        return type(self) == type(other)
+
 
 class FieldQuery(Query):
     """An abstract query that searches in a specific field for a
@@ -106,6 +109,10 @@ class FieldQuery(Query):
     def match(self, item):
         return self.value_match(self.pattern, item.get(self.field))
 
+    def __eq__(self, other):
+        return super(FieldQuery, self).__eq__(other) and \
+               self.field == other.field and self.pattern == other.pattern
+
 
 class MatchQuery(FieldQuery):
     """A query that looks for exact matches in an item field."""
@@ -120,8 +127,7 @@ class MatchQuery(FieldQuery):
 class NoneQuery(FieldQuery):
 
     def __init__(self, field, fast=True):
-        self.field = field
-        self.fast = fast
+        super(NoneQuery, self).__init__(field, None, fast)
 
     def col_clause(self):
         return self.field + " IS NULL", ()
@@ -337,6 +343,10 @@ class CollectionQuery(Query):
         clause = (' ' + joiner + ' ').join(clause_parts)
         return clause, subvals
 
+    def __eq__(self, other):
+        return super(CollectionQuery, self).__eq__(other) and \
+               self.subqueries == other.subqueries
+
 
 class AnyFieldQuery(CollectionQuery):
     """A query that matches if a given FieldQuery subclass matches in
@@ -361,6 +371,10 @@ class AnyFieldQuery(CollectionQuery):
             if subq.match(item):
                 return True
         return False
+
+    def __eq__(self, other):
+        return super(AnyFieldQuery, self).__eq__(other) and \
+               self.query_class == other.query_class
 
 
 class MutableCollectionQuery(CollectionQuery):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -730,3 +730,15 @@ class NullSort(Sort):
     """No sorting. Leave results unsorted."""
     def sort(items):
         return items
+
+    def __nonzero__(self):
+        return self.__bool__()
+
+    def __bool__(self):
+        return False
+
+    def __eq__(self, other):
+        return type(self) == type(other) or other is None
+
+    def __hash__(self):
+        return 0

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -625,6 +625,12 @@ class Sort(object):
         """
         return False
 
+    def __hash__(self):
+        return 0
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
 
 class MultipleSort(Sort):
     """Sort that encapsulates multiple sub-sorts.
@@ -686,6 +692,13 @@ class MultipleSort(Sort):
     def __repr__(self):
         return u'MultipleSort({0})'.format(repr(self.sorts))
 
+    def __hash__(self):
+        return hash(tuple(self.sorts))
+
+    def __eq__(self, other):
+        return super(MultipleSort, self).__eq__(other) and \
+               self.sorts == other.sorts
+
 
 class FieldSort(Sort):
     """An abstract sort criterion that orders by a specific field (of
@@ -708,6 +721,14 @@ class FieldSort(Sort):
             self.field,
             '+' if self.ascending else '-',
         )
+
+    def __hash__(self):
+        return hash((self.field, self.ascending))
+
+    def __eq__(self, other):
+        return super(FieldSort, self).__eq__(other) and \
+               self.field == other.field and \
+               self.ascending == other.ascending
 
 
 class FixedFieldSort(FieldSort):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -111,7 +111,7 @@ class FieldQuery(Query):
 
     def __eq__(self, other):
         return super(FieldQuery, self).__eq__(other) and \
-               self.field == other.field and self.pattern == other.pattern
+            self.field == other.field and self.pattern == other.pattern
 
 
 class MatchQuery(FieldQuery):
@@ -345,7 +345,7 @@ class CollectionQuery(Query):
 
     def __eq__(self, other):
         return super(CollectionQuery, self).__eq__(other) and \
-               self.subqueries == other.subqueries
+            self.subqueries == other.subqueries
 
 
 class AnyFieldQuery(CollectionQuery):
@@ -374,7 +374,7 @@ class AnyFieldQuery(CollectionQuery):
 
     def __eq__(self, other):
         return super(AnyFieldQuery, self).__eq__(other) and \
-               self.query_class == other.query_class
+            self.query_class == other.query_class
 
 
 class MutableCollectionQuery(CollectionQuery):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -177,8 +177,8 @@ class RegexpQuery(StringFieldQuery):
     Raises InvalidQueryError when the pattern is not a valid regular
     expression.
     """
-    def __init__(self, field, pattern, false=True):
-        super(RegexpQuery, self).__init__(field, pattern, false)
+    def __init__(self, field, pattern, fast=True):
+        super(RegexpQuery, self).__init__(field, pattern, fast)
         try:
             self.pattern = re.compile(self.pattern)
         except re.error as exc:

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -152,12 +152,14 @@ def sort_from_strings(model_cls, sort_parts):
     """Create a `Sort` from a list of sort criteria (strings).
     """
     if not sort_parts:
-        return query.NullSort()
+        sort = query.NullSort()
+    elif len(sort_parts) == 1:
+        sort = construct_sort_part(model_cls, sort_parts[0])
     else:
         sort = query.MultipleSort()
         for part in sort_parts:
             sort.add_sort(construct_sort_part(model_cls, part))
-        return sort
+    return sort
 
 
 def parse_sorted_query(model_cls, parts, prefixes={},

--- a/beets/library.py
+++ b/beets/library.py
@@ -270,15 +270,15 @@ class LibModel(dbcore.Model):
 
     def store(self):
         super(LibModel, self).store()
-        plugins.send('database_change', lib=self._db)
+        plugins.send('database_change', lib=self._db, model=self)
 
     def remove(self):
         super(LibModel, self).remove()
-        plugins.send('database_change', lib=self._db)
+        plugins.send('database_change', lib=self._db, model=self)
 
     def add(self, lib=None):
         super(LibModel, self).add(lib)
-        plugins.send('database_change', lib=self._db)
+        plugins.send('database_change', lib=self._db, model=self)
 
     def __format__(self, spec):
         if not spec:

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -80,7 +80,7 @@ class MPDUpdatePlugin(BeetsPlugin):
 
         self.register_listener('database_change', self.db_change)
 
-    def db_change(self, lib):
+    def db_change(self, lib, model):
         self.register_listener('cli_exit', self.update)
 
     def update(self, lib):

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -55,7 +55,7 @@ class PlexUpdate(BeetsPlugin):
 
         self.register_listener('database_change', self.listen_for_db_change)
 
-    def listen_for_db_change(self, lib):
+    def listen_for_db_change(self, lib, model):
         """Listens for beets db change and register the update for the end"""
         self.register_listener('cli_exit', self.update)
 

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -107,14 +107,19 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     queries, sorts = zip(*(parse_query_string(q, Model)
                                            for q in qs))
                     query = OrQuery(queries)
-                    sort = MultipleSort()
+                    final_sorts = []
                     for s in sorts:
                         if s:
-                            sort.add_sort(s)
-                    if not sort.sorts:
+                            if isinstance(s, MultipleSort):
+                                final_sorts += s.sorts
+                            else:
+                                final_sorts.append(s)
+                    if not final_sorts:
                         sort = None
-                    elif len(sort.sorts) == 1:
-                        sort = sort.sorts[0]
+                    elif len(final_sorts) == 1:
+                        sort, = final_sorts
+                    else:
+                        sort = MultipleSort(final_sorts)
                     query_and_sort = query, sort
 
                 playlist_data += (query_and_sort,)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -65,7 +65,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         spl_update.func = update
         return [spl_update]
 
-    def db_change(self, lib):
+    def db_change(self, lib, model):
         self.register_listener('cli_exit', self.update_playlists)
 
     def update_playlists(self, lib):

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -58,9 +58,9 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 if not a.endswith(".m3u"):
                     args.add("{0}.m3u".format(a))
 
-            playlists = {(name, q, a_q)
-                         for name, q, a_q in self._unmatched_playlists
-                         if name in args}
+            playlists = set((name, q, a_q)
+                            for name, q, a_q in self._unmatched_playlists
+                            if name in args)
             if not playlists:
                 raise ui.UserError('No playlist matching any of {0} '
                                    'found'.format([name for name, _, _ in

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -21,30 +21,13 @@ from __future__ import (division, absolute_import, print_function,
 from beets.plugins import BeetsPlugin
 from beets import ui
 from beets.util import mkdirall, normpath, syspath
+from beets.library import Item, Album, parse_query_parts
+from beets.dbcore import OrQuery
 import os
 
 
-def _items_for_query(lib, queries, album):
-    """Get the matching items for a list of queries.
-
-    `queries` can either be a single string or a list of strings. In the
-    latter case, the results from each query are concatenated. `album`
-    indicates whether the queries are item-level or album-level.
-    """
-    if isinstance(queries, basestring):
-        queries = [queries]
-    if album:
-        for query in queries:
-            for album in lib.albums(query):
-                for item in album.items():
-                    yield item
-    else:
-        for query in queries:
-            for item in lib.items(query):
-                yield item
-
-
 class SmartPlaylistPlugin(BeetsPlugin):
+
     def __init__(self):
         super(SmartPlaylistPlugin, self).__init__()
         self.config.add({
@@ -54,42 +37,96 @@ class SmartPlaylistPlugin(BeetsPlugin):
             'playlists': []
         })
 
+        self._matched_playlists = None
+        self._unmatched_playlists = None
+
         if self.config['auto']:
             self.register_listener('database_change', self.db_change)
 
     def commands(self):
         def update(lib, opts, args):
+            self.build_queries()
+            self._matched_playlists = self._unmatched_playlists
             self.update_playlists(lib)
         spl_update = ui.Subcommand('splupdate',
                                    help='update the smart playlists')
         spl_update.func = update
         return [spl_update]
 
+    def build_queries(self):
+        """
+        Instanciate queries for the playlists.
+
+        Each playlist has 2 queries: one or items one for albums. We must also
+        remember its name. _unmatched_playlists is a set of tuples
+        (name, q, album_q).
+        """
+        self._unmatched_playlists = set()
+        self._matched_playlists = set()
+
+        for playlist in self.config['playlists'].get(list):
+            playlist_data = (playlist['name'],)
+            for key, Model in (('query', Item), ('album_query', Album)):
+                qs = playlist.get(key)
+                # FIXME sort mgmt
+                if qs is None:
+                    query = None
+                    sort = None
+                elif isinstance(qs, basestring):
+                    query, sort = parse_query_parts(qs, Model)
+                else:
+                    query = OrQuery([parse_query_parts(q, Model)[0]
+                                     for q in qs])
+                    sort = None
+                playlist_data += (query,)
+
+            self._unmatched_playlists.add(playlist_data)
+
     def db_change(self, lib, model):
-        self.register_listener('cli_exit', self.update_playlists)
+        if self._unmatched_playlists is None:
+            self.build_queries()
+
+        for playlist in self._unmatched_playlists:
+            n, q, a_q = playlist
+            if a_q and isinstance(model, Album):
+                matches = a_q.match(model)
+            elif q and isinstance(model, Item):
+                matches = q.match(model) or q.match(model.get_album())
+            else:
+                matches = False
+
+            if matches:
+                self._log.debug("{0} will be updated because of {1}", n, model)
+                self._matched_playlists.add(playlist)
+                self.register_listener('cli_exit', self.update_playlists)
+
+        self._unmatched_playlists -= self._matched_playlists
 
     def update_playlists(self, lib):
-        self._log.info("Updating smart playlists...")
-        playlists = self.config['playlists'].get(list)
+        self._log.info("Updating {0} smart playlists...",
+                       len(self._matched_playlists))
+
         playlist_dir = self.config['playlist_dir'].as_filename()
         relative_to = self.config['relative_to'].get()
         if relative_to:
             relative_to = normpath(relative_to)
 
-        for playlist in playlists:
-            self._log.debug(u"Creating playlist {0[name]}", playlist)
+        for playlist in self._matched_playlists:
+            name, query, album_query = playlist
+            self._log.debug(u"Creating playlist {0}", name)
             items = []
-            if 'album_query' in playlist:
-                items.extend(_items_for_query(lib, playlist['album_query'],
-                                              True))
-            if 'query' in playlist:
-                items.extend(_items_for_query(lib, playlist['query'], False))
+
+            if query:
+                items.extend(lib.items(query))
+            if album_query:
+                for album in lib.albums(album_query):
+                    items.extend(album.items())
 
             m3us = {}
             # As we allow tags in the m3u names, we'll need to iterate through
             # the items and generate the correct m3u file names.
             for item in items:
-                m3u_name = item.evaluate_template(playlist['name'], True)
+                m3u_name = item.evaluate_template(name, True)
                 if m3u_name not in m3us:
                     m3us[m3u_name] = []
                 item_path = item.path
@@ -104,4 +141,4 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 with open(syspath(m3u_path), 'w') as f:
                     for path in m3us[m3u]:
                         f.write(path + b'\n')
-        self._log.info("{0} playlists updated", len(playlists))
+        self._log.info("{0} playlists updated", len(self._matched_playlists))

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -96,6 +96,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     query = OrQuery([parse_query_string(q, Model)[0]
                                      for q in qs])
                     sort = None
+                del sort  # FIXME
                 playlist_data += (query,)
 
             self._unmatched_playlists.add(playlist_data)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -62,8 +62,10 @@ class SmartPlaylistPlugin(BeetsPlugin):
                          for name, q, a_q in self._unmatched_playlists
                          if name in args}
             if not playlists:
-                # raise UserError
-                pass
+                raise ui.UserError('No playlist matching any of {0} '
+                                   'found'.format([name for name, _, _ in
+                                                   self._unmatched_playlists]))
+
             self._matched_playlists = playlists
             self._unmatched_playlists -= playlists
         else:

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -21,7 +21,7 @@ from __future__ import (division, absolute_import, print_function,
 from beets.plugins import BeetsPlugin
 from beets import ui
 from beets.util import mkdirall, normpath, syspath
-from beets.library import Item, Album, parse_query_parts
+from beets.library import Item, Album, parse_query_string
 from beets.dbcore import OrQuery
 import os
 
@@ -91,9 +91,9 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     query = None
                     sort = None
                 elif isinstance(qs, basestring):
-                    query, sort = parse_query_parts(qs, Model)
+                    query, sort = parse_query_string(qs, Model)
                 else:
-                    query = OrQuery([parse_query_parts(q, Model)[0]
+                    query = OrQuery([parse_query_string(q, Model)[0]
                                      for q in qs])
                     sort = None
                 playlist_data += (query,)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 Features:
 
+* :doc:`/plugins/smartplaylist`: detect for each playlist if it needs to be
+  regenated, instead of systematically regenerating all of them after a
+  database modification.
+* :doc:`/plugins/smartplaylist`: the ``splupdate`` command can now take
+  additinal parameters: names of the playlists to regenerate.
 * Beets now accept top-level options ``--format-item`` and ``--format-album``
   before any subcommand to control how items and albums are displayed.
   :bug:`1271`:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -128,6 +128,8 @@ Fixes:
 
 For developers:
 
+* The ``database_change`` event now sends the item or album that is subject to
+  a change in the db.
 * the ``OptionParser`` is now a ``CommonOptionsParser`` that offers facilities
   for adding usual options (``--album``, ``--path`` and ``--format``). See
   :ref:`add_subcommands`. :bug:`1271`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ Features:
   additinal parameters: names of the playlists to regenerate.
 * Beets now accept top-level options ``--format-item`` and ``--format-album``
   before any subcommand to control how items and albums are displayed.
-  :bug:`1271`:
+  :bug:`1271`
 * :doc:`/plugins/replaygain`: There is a new backend for the `bs1770gain`_
   tool. Thanks to :user:`jmwatte`. :bug:`1343`
 * There are now multiple levels of verbosity. On the command line, you can

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extlinks = {
 }
 
 # Options for HTML output
-html_theme = 'default'
+html_theme = 'classic'
 htmlhelp_basename = 'beetsdoc'
 
 # Options for LaTeX output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extlinks = {
 }
 
 # Options for HTML output
-html_theme = 'classic'
+html_theme = 'default'
 htmlhelp_basename = 'beetsdoc'
 
 # Options for LaTeX output

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -203,7 +203,7 @@ The events currently available are:
   Library object. Parameter: ``lib``.
 
 * *database_change*: a modification has been made to the library database. The
-  change might not be committed yet. Parameter: ``lib``.
+  change might not be committed yet. Parameters: ``lib`` and ``model``.
 
 * *cli_exit*: called just before the ``beet`` command-line program exits.
   Parameter: ``lib``.

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -44,6 +44,18 @@ You can also gather the results of several queries by putting them in a list.
     - name: 'BeatlesUniverse.m3u'
       query: ['artist:beatles', 'genre:"beatles cover"']
 
+Note that since beets query syntax is in effect, you can also use sorting
+directives::
+
+    - name: 'Chronological Beatles'
+      query: 'artist:Beatles year+'
+    - name: 'Mixed Rock'
+      query: ['artist:Beatles year+', 'artist:"Led Zeppelin" bitrate+']
+
+The former case behaves as expected, however please note that in the latter the
+sorts will be merged: ``year+ bitrate+`` will apply to both the Beatles and Led
+Zeppelin. If that bothers you, please get in touch.
+
 For querying albums instead of items (mainly useful with extensible fields),
 use the ``album_query`` field. ``query`` and ``album_query`` can be used at the
 same time. The following example gathers single items but also items belonging

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -53,13 +53,16 @@ to albums that have a ``for_travel`` extensible field set to 1::
       album_query: 'for_travel:1'
       query: 'for_travel:1'
 
-By default, all playlists are automatically regenerated at the end of the
-session if the library database was changed. To force regeneration, you can
-invoke it manually from the command line::
+By default, each playlist is automatically regenerated at the end of the
+session if an item or album it matches changed in the library database. To
+force regeneration, you can invoke it manually from the command line::
 
     $ beet splupdate
 
-which will generate your new smart playlists.
+This will regenerate all smart playlists. You can also specify which ones you
+want to regenerate::
+
+    $ beet splupdate BeatlesUniverse.m3u MyTravelPlaylist
 
 You can also use this plugin together with the :doc:`mpdupdate`, in order to
 automatically notify MPD of the playlist change, by adding ``mpdupdate`` to

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -449,6 +449,7 @@ class SortFromStringsTest(unittest.TestCase):
     def test_zero_parts(self):
         s = self.sfs([])
         self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(s, dbcore.query.NullSort())
 
     def test_one_parts(self):
         s = self.sfs(['field+'])
@@ -461,17 +462,17 @@ class SortFromStringsTest(unittest.TestCase):
 
     def test_fixed_field_sort(self):
         s = self.sfs(['field_one+'])
-        self.assertIsInstance(s, dbcore.query.MultipleSort)
-        self.assertIsInstance(s.sorts[0], dbcore.query.FixedFieldSort)
+        self.assertIsInstance(s, dbcore.query.FixedFieldSort)
+        self.assertEqual(s, dbcore.query.FixedFieldSort('field_one'))
 
     def test_flex_field_sort(self):
         s = self.sfs(['flex_field+'])
-        self.assertIsInstance(s, dbcore.query.MultipleSort)
-        self.assertIsInstance(s.sorts[0], dbcore.query.SlowFieldSort)
+        self.assertIsInstance(s, dbcore.query.SlowFieldSort)
+        self.assertEqual(s, dbcore.query.SlowFieldSort('flex_field'))
 
     def test_special_sort(self):
         s = self.sfs(['some_sort+'])
-        self.assertIsInstance(s.sorts[0], TestSort)
+        self.assertIsInstance(s, TestSort)
 
 
 class ResultsIteratorTest(unittest.TestCase):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -16,8 +16,9 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 import os
-from mock import patch
+from mock import patch, Mock
 import shutil
+import itertools
 
 from beets.importer import SingletonImportTask, SentinelImportTask, \
     ArchiveImportTask
@@ -57,7 +58,6 @@ class ItemTypesTest(unittest.TestCase, TestHelper):
 
     def setUp(self):
         self.setup_plugin_loader()
-        self.setup_beets()
 
     def tearDown(self):
         self.teardown_plugin_loader()
@@ -308,6 +308,96 @@ class ListenersTest(unittest.TestCase, TestHelper):
         d.register_listener('cli_exit', d2.dummy)
         self.assertEqual(DummyPlugin._raw_listeners['cli_exit'],
                          [d.dummy, d2.dummy])
+
+    @patch('beets.plugins.find_plugins')
+    @patch('beets.plugins.inspect')
+    def test_events_called(self, mock_inspect, mock_find_plugins):
+        mock_inspect.getargspec.return_value = None
+
+        class DummyPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super(DummyPlugin, self).__init__()
+                self.foo = Mock(__name__=b'foo')
+                self.register_listener('event_foo', self.foo)
+                self.bar = Mock(__name__=b'bar')
+                self.register_listener('event_bar', self.bar)
+
+        d = DummyPlugin()
+        mock_find_plugins.return_value = d,
+
+        plugins.send('event')
+        d.foo.assert_has_calls([])
+        d.bar.assert_has_calls([])
+
+        plugins.send('event_foo', var="tagada")
+        d.foo.assert_called_once_with(var="tagada")
+        d.bar.assert_has_calls([])
+
+    @patch('beets.plugins.find_plugins')
+    def test_listener_params(self, mock_find_plugins):
+        test = self
+
+        class DummyPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super(DummyPlugin, self).__init__()
+                for i in itertools.count(1):
+                    try:
+                        meth = getattr(self, 'dummy{0}'.format(i))
+                    except AttributeError:
+                        break
+                    self.register_listener('event{0}'.format(i), meth)
+
+            def dummy1(self, foo):
+                test.assertEqual(foo, 5)
+
+            def dummy2(self, foo=None):
+                test.assertEqual(foo, 5)
+
+            def dummy3(self):
+                # argument cut off
+                pass
+
+            def dummy4(self, bar=None):
+                # argument cut off
+                pass
+
+            def dummy5(self, bar):
+                test.assertFalse(True)
+
+            # more complex exmaples
+
+            def dummy6(self, foo, bar=None):
+                test.assertEqual(foo, 5)
+                test.assertEqual(bar, None)
+
+            def dummy7(self, foo, **kwargs):
+                test.assertEqual(foo, 5)
+                test.assertEqual(kwargs, {})
+
+            def dummy8(self, foo, bar, **kwargs):
+                test.assertFalse(True)
+
+            def dummy9(self, **kwargs):
+                test.assertEqual(kwargs, {"foo": 5})
+
+        d = DummyPlugin()
+        mock_find_plugins.return_value = d,
+
+        plugins.send('event1', foo=5)
+        plugins.send('event2', foo=5)
+        plugins.send('event3', foo=5)
+        plugins.send('event4', foo=5)
+
+        with self.assertRaises(TypeError):
+            plugins.send('event5', foo=5)
+
+        plugins.send('event6', foo=5)
+        plugins.send('event7', foo=5)
+
+        with self.assertRaises(TypeError):
+            plugins.send('event8', foo=5)
+
+        plugins.send('event9', foo=5)
 
 
 def suite():

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -60,6 +60,16 @@ class AnyFieldQueryTest(_common.LibTestCase):
                                        dbcore.query.SubstringQuery)
         self.assertEqual(self.lib.items(q).get(), None)
 
+    def test_eq(self):
+        q1 = dbcore.query.AnyFieldQuery('foo', ['bar'],
+                                        dbcore.query.SubstringQuery)
+        q2 = dbcore.query.AnyFieldQuery('foo', ['bar'],
+                                        dbcore.query.SubstringQuery)
+        self.assertEqual(q1, q2)
+
+        q2.query_class = None
+        self.assertNotEqual(q1, q2)
+
 
 class AssertsMixin(object):
     def assert_items_matched(self, results, titles):
@@ -343,6 +353,16 @@ class MatchTest(_common.TestCase):
 
     def test_open_range(self):
         dbcore.query.NumericQuery('bitrate', '100000..')
+
+    def test_eq(self):
+        q1 = dbcore.query.MatchQuery('foo', 'bar')
+        q2 = dbcore.query.MatchQuery('foo', 'bar')
+        q3 = dbcore.query.MatchQuery('foo', 'baz')
+        q4 = dbcore.query.StringFieldQuery('foo', 'bar')
+        self.assertEqual(q1, q2)
+        self.assertNotEqual(q1, q3)
+        self.assertNotEqual(q1, q4)
+        self.assertNotEqual(q3, q4)
 
 
 class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -78,7 +78,8 @@ class SmartPlaylistTest(unittest.TestCase):
         ])
 
         spl.build_queries()
-        sorts = {name: sort for name, (_, sort), _ in spl._unmatched_playlists}
+        sorts = dict((name, sort)
+                     for name, (_, sort), _ in spl._unmatched_playlists)
 
         asseq = self.assertEqual  # less cluttered code
         S = FixedFieldSort  # short cut since we're only dealing with this

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -15,19 +15,128 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
+from os import path
+from tempfile import mkdtemp
+from shutil import rmtree
+
+from mock import Mock, MagicMock
+
+from beetsplug.smartplaylist import SmartPlaylistPlugin
+from beets.library import Item, Album, parse_query_string
+from beets.dbcore import OrQuery
+from beets.util import syspath
+from beets import config
+
 from test._common import unittest
 from test.helper import TestHelper
 
 
 class SmartPlaylistTest(unittest.TestCase):
     def test_build_queries(self):
-        pass
+        spl = SmartPlaylistPlugin()
+        self.assertEqual(spl._matched_playlists, None)
+        self.assertEqual(spl._unmatched_playlists, None)
+
+        config['smartplaylist']['playlists'].set([])
+        spl.build_queries()
+        self.assertEqual(spl._matched_playlists, set())
+        self.assertEqual(spl._unmatched_playlists, set())
+
+        config['smartplaylist']['playlists'].set([
+            {'name': 'foo',
+             'query': 'FOO foo'},
+            {'name': 'bar',
+             'album_query': ['BAR bar1', 'BAR bar2']},
+            {'name': 'baz',
+             'query': 'BAZ baz',
+             'album_query': 'BAZ baz'}
+        ])
+        spl.build_queries()
+        self.assertEqual(spl._matched_playlists, set())
+        foo_foo, _ = parse_query_string('FOO foo', Item)
+        bar_bar = OrQuery([parse_query_string('BAR bar1', Album)[0],
+                           parse_query_string('BAR bar2', Album)[0]])
+        baz_baz, _ = parse_query_string('BAZ baz', Item)
+        baz_baz2, _ = parse_query_string('BAZ baz', Album)
+        self.assertEqual(spl._unmatched_playlists, {
+            ('foo', foo_foo, None),
+            ('bar', None, bar_bar),
+            ('baz', baz_baz, baz_baz2)
+        })
 
     def test_db_changes(self):
-        pass
+        spl = SmartPlaylistPlugin()
+
+        i1 = MagicMock(Item)
+        i2 = MagicMock(Item)
+        a = MagicMock(Album)
+        i1.get_album.return_value = a
+
+        q1 = Mock()
+        q1.matches.side_effect = {i1: False, i2: False}.__getitem__
+        a_q1 = Mock()
+        a_q1.matches.side_effect = {a: True}.__getitem__
+        q2 = Mock()
+        q2.matches.side_effect = {i1: False, i2: True}.__getitem__
+
+        pl1 = ('1', q1, a_q1)
+        pl2 = ('2', None, a_q1)
+        pl3 = ('3', q2, None)
+
+        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._matched_playlists = set()
+        spl.db_change(None, i1)
+        self.assertEqual(spl._unmatched_playlists, {pl2})
+        self.assertEqual(spl._matched_playlists, {pl1, pl3})
+
+        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._matched_playlists = set()
+        spl.db_change(None, i2)
+        self.assertEqual(spl._unmatched_playlists, {pl2})
+        self.assertEqual(spl._matched_playlists, {pl1, pl3})
+
+        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._matched_playlists = set()
+        spl.db_change(None, a)
+        self.assertEqual(spl._unmatched_playlists, {pl3})
+        self.assertEqual(spl._matched_playlists, {pl1, pl2})
+        spl.db_change(None, i2)
+        self.assertEqual(spl._unmatched_playlists, set())
+        self.assertEqual(spl._matched_playlists, {pl1, pl2, pl3})
 
     def test_playlist_update(self):
-        pass
+        spl = SmartPlaylistPlugin()
+
+        i = Mock(path='/tagada.mp3')
+        i.evaluate_template.side_effect = lambda x, _: x
+        q = Mock()
+        a_q = Mock()
+        lib = Mock()
+        lib.items.return_value = [i]
+        lib.albums.return_value = []
+        pl = 'my_playlist.m3u', q, a_q
+        spl._matched_playlists = {pl}
+
+        dir = mkdtemp()
+        config['smartplaylist']['relative_to'] = False
+        config['smartplaylist']['playlist_dir'] = dir
+        try:
+            spl.update_playlists(lib)
+        except Exception:
+            rmtree(dir)
+            raise
+
+        lib.items.assert_called_once_with(q)
+        lib.albums.assert_called_once_with(a_q)
+
+        m3u_filepath = path.join(dir, pl[0])
+        self.assertTrue(path.exists(m3u_filepath), m3u_filepath)
+
+        with open(syspath(m3u_filepath), 'r') as f:
+            content = f.readlines()
+        rmtree(dir)
+
+        self.assertEqual(content, ["/tagada.mp3\n"])
 
 
 class SmartPlaylistCLITest(unittest.TestCase, TestHelper):

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -1,0 +1,41 @@
+# This file is part of beets.
+# Copyright 2015, Bruno Cauet.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+from test._common import unittest
+from beetsplug import smartplaylist
+from beets import config, ui
+
+from test.helper import TestHelper
+
+
+class SmartPlaylistTest(unittest.TestCase):
+    def test_build_queries(self):
+        pass
+
+    def test_db_changes(self):
+        pass
+
+    def test_playlist_update(self):
+        pass
+
+
+class SmartPlaylistCLITest(unittest.TestCase, TestHelper):
+    def test_import(self):
+        pass
+
+    def test_splupdate(self):
+        pass

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -59,11 +59,11 @@ class SmartPlaylistTest(unittest.TestCase):
                            parse_query_string('BAR bar2', Album)[0]])
         baz_baz, _ = parse_query_string('BAZ baz', Item)
         baz_baz2, _ = parse_query_string('BAZ baz', Album)
-        self.assertEqual(spl._unmatched_playlists, {
+        self.assertEqual(spl._unmatched_playlists, set([
             ('foo', foo_foo, None),
             ('bar', None, bar_bar),
             ('baz', baz_baz, baz_baz2)
-        })
+        ]))
 
     def test_db_changes(self):
         spl = SmartPlaylistPlugin()
@@ -84,26 +84,26 @@ class SmartPlaylistTest(unittest.TestCase):
         pl2 = ('2', None, a_q1)
         pl3 = ('3', q2, None)
 
-        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._unmatched_playlists = set([pl1, pl2, pl3])
         spl._matched_playlists = set()
         spl.db_change(None, i1)
-        self.assertEqual(spl._unmatched_playlists, {pl2})
-        self.assertEqual(spl._matched_playlists, {pl1, pl3})
+        self.assertEqual(spl._unmatched_playlists, set([pl2]))
+        self.assertEqual(spl._matched_playlists, set([pl1, pl3]))
 
-        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._unmatched_playlists = set([pl1, pl2, pl3])
         spl._matched_playlists = set()
         spl.db_change(None, i2)
-        self.assertEqual(spl._unmatched_playlists, {pl2})
-        self.assertEqual(spl._matched_playlists, {pl1, pl3})
+        self.assertEqual(spl._unmatched_playlists, set([pl2]))
+        self.assertEqual(spl._matched_playlists, set([pl1, pl3]))
 
-        spl._unmatched_playlists = {pl1, pl2, pl3}
+        spl._unmatched_playlists = set([pl1, pl2, pl3])
         spl._matched_playlists = set()
         spl.db_change(None, a)
-        self.assertEqual(spl._unmatched_playlists, {pl3})
-        self.assertEqual(spl._matched_playlists, {pl1, pl2})
+        self.assertEqual(spl._unmatched_playlists, set([pl3]))
+        self.assertEqual(spl._matched_playlists, set([pl1, pl2]))
         spl.db_change(None, i2)
         self.assertEqual(spl._unmatched_playlists, set())
-        self.assertEqual(spl._matched_playlists, {pl1, pl2, pl3})
+        self.assertEqual(spl._matched_playlists, set([pl1, pl2, pl3]))
 
     def test_playlist_update(self):
         spl = SmartPlaylistPlugin()
@@ -116,7 +116,7 @@ class SmartPlaylistTest(unittest.TestCase):
         lib.items.return_value = [i]
         lib.albums.return_value = []
         pl = 'my_playlist.m3u', q, a_q
-        spl._matched_playlists = {pl}
+        spl._matched_playlists = [pl]
 
         dir = mkdtemp()
         config['smartplaylist']['relative_to'] = False

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -16,9 +16,6 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 from test._common import unittest
-from beetsplug import smartplaylist
-from beets import config, ui
-
 from test.helper import TestHelper
 
 


### PR DESCRIPTION
`database_changed` sends the model that changed (stored/deleted/updated) and the `smartplaylist` plugin uses that information to detect which playlists it should regenerate.
Query usage has also been improved: the plugin uses `OrQuery`, which is way faster that merging individual queries.

This is a work in progress:
- [x] there seems to be problems on query building: Kings of Leon matches my French playlist according to smartplaylist, but `ls` disagrees.
- [x] sort is not managed. There does not seem to be a right way to deal with it.
- [x] there are only skeletons of tests
- [x] the update to `database_changed` should be documented
- [x] maybe a let's-find-what-this-function-needs approach in the function wrapper (beets/plugins.py:114) should be restored (@sampsyo I need your input there).

edit: motivation for that change: playlist building can be really slow (1min+), even if I barely did anything. This solves it.