### PR TITLE
ftintitle plugin now allows a custom format to be defined

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -82,6 +82,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'drop': False,
+            'format': u'feat. {}'
         })
 
         self._command = ui.Subcommand(
@@ -116,12 +117,13 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         """Import hook for moving featuring artist automatically.
         """
         drop_feat = self.config['drop'].get(bool)
+        feat_format = self.config['format'].get(unicode)
 
         for item in task.imported_items():
-            self.ft_in_title(item, drop_feat)
+            self.ft_in_title(item, drop_feat, feat_format)
             item.store()
 
-    def update_metadata(self, item, feat_part, drop_feat):
+    def update_metadata(self, item, feat_part, drop_feat, feat_format):
         """Choose how to add new artists to the title and set the new
         metadata. Also, print out messages about any changes that are made.
         If `drop_feat` is set, then do not add the artist to the title; just
@@ -137,11 +139,12 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
         if not drop_feat and not contains_feat(item.title):
-            new_title = u"{0} feat. {1}".format(item.title, feat_part)
+            new_format = feat_format.format(feat_part)
+            new_title = u"{0} {1}".format(item.title, new_format)
             self._log.info(u'title: {0} -> {1}', item.title, new_title)
             item.title = new_title
 
-    def ft_in_title(self, item, drop_feat):
+    def ft_in_title(self, item, drop_feat, feat_format):
         """Look for featured artists in the item's artist fields and move
         them to the title.
         """
@@ -162,6 +165,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
             # If we have a featuring artist, move it to the title.
             if feat_part:
-                self.update_metadata(item, feat_part, drop_feat)
+                self.update_metadata(item, feat_part, drop_feat, feat_format)
             else:
                 self._log.info(u'no featuring artists found')

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -24,6 +24,9 @@ file. The available options are:
 - **drop**: Remove featured artists entirely instead of adding them to the
   title field.
   Default: ``no``.
+- **format**: Defines the format for the feat part of the new title field.
+  In this format the ``{}`` is used to define where the featured artists are placed
+  Default: ``feat. {}``
 
 Running Manually
 ----------------


### PR DESCRIPTION
I have updated the ftintitle plugin to allow a custom format to be defined. The default format is that which was previously hardcoded.

This pull request allows formats like the list below to be defined:
* feat. ...
* (Feat. ...)
* ft. ...
* featuring ...

This is my first commit to an open source project, so I'm still working my way around the beets project. Any feedback would be great. 

Thanks