### PR TITLE
Config: new option -r redacts sensitive fields

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1475,7 +1475,7 @@ def config_func(lib, opts, args):
 
     # Dump configuration.
     else:
-        print(config.dump(full=opts.defaults))
+        print(config.dump(full=opts.defaults, redact_fields=opts.redacted))
 
 
 def config_edit():
@@ -1505,6 +1505,10 @@ config_cmd.parser.add_option(
 config_cmd.parser.add_option(
     '-d', '--defaults', action='store_true',
     help='include the default configuration'
+)
+config_cmd.parser.add_option(
+    '-r', '--redacted', action='store_true',
+    help='redact sensitive fields'
 )
 config_cmd.func = config_func
 default_commands.append(config_cmd)

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -405,11 +405,8 @@ class RootView(ConfigView):
     def root(self):
         return self
 
-    def add_redacted_fields(self, field_names):
-        if not isinstance(field_names, list):
-            field_names = [field_names]
-
-        self.redacted_fields = self.redacted_fields | set(field_names)
+    def add_redacted_fields(self, *field_names):
+        self.redacted_fields |= set(field_names)
 
 
 class Subview(ConfigView):
@@ -462,8 +459,8 @@ class Subview(ConfigView):
     def root(self):
         return self.parent.root()
 
-    def add_redacted_fields(self, field_names):
-        self.parent.add_redacted_fields(field_names)
+    def add_redacted_fields(self, *field_names):
+        self.parent.add_redacted_fields(*field_names)
 
 
 # Config file paths, including platform-specific paths and in-package
@@ -821,8 +818,7 @@ class Configuration(RootView):
             out_dict = RootView(sources).flatten()
 
         if redact_fields:
-            Dumper.redacted_fields = Dumper.redacted_fields | \
-                self.redacted_fields
+            Dumper.redacted_fields |= self.redacted_fields
         else:
             Dumper.redacted_fields = set()
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -56,7 +56,7 @@ class DiscogsPlugin(BeetsPlugin):
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
         })
-        self.config.add_redacted_fields(['apikey', 'apisecret'])
+        self.config.add_redacted_fields('apikey', 'apisecret')
         self.discogs_client = None
         self.register_listener('import_begin', self.setup)
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -56,6 +56,7 @@ class DiscogsPlugin(BeetsPlugin):
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
         })
+        self.config.add_redacted_fields(['apikey', 'apisecret'])
         self.discogs_client = None
         self.register_listener('import_begin', self.setup)
 

--- a/beetsplug/echonest.py
+++ b/beetsplug/echonest.py
@@ -135,6 +135,7 @@ class EchonestMetadataPlugin(plugins.BeetsPlugin):
             'truncate': True,
         })
         self.config.add(ATTRIBUTES)
+        self.config.add_redacted_fields(['apikey'])
 
         pyechonest.config.ECHO_NEST_API_KEY = \
             self.config['apikey'].get(unicode)

--- a/beetsplug/echonest.py
+++ b/beetsplug/echonest.py
@@ -135,7 +135,7 @@ class EchonestMetadataPlugin(plugins.BeetsPlugin):
             'truncate': True,
         })
         self.config.add(ATTRIBUTES)
-        self.config.add_redacted_fields(['apikey'])
+        self.config.add_redacted_fields('apikey')
 
         pyechonest.config.ECHO_NEST_API_KEY = \
             self.config['apikey'].get(unicode)

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -463,6 +463,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
             'force': False,
             'sources': self.SOURCES,
         })
+        self.config.add_redacted_fields(['google_API_key', 'google_engine_ID'])
 
         available_sources = list(self.SOURCES)
         if not self.config['google_API_key'].get() and \

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -463,7 +463,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
             'force': False,
             'sources': self.SOURCES,
         })
-        self.config.add_redacted_fields(['google_API_key', 'google_engine_ID'])
+        self.config.add_redacted_fields('google_API_key', 'google_engine_ID')
 
         available_sources = list(self.SOURCES)
         if not self.config['google_API_key'].get() and \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,8 @@ Features:
   flexible attribute `data_source` of an Item/Album. :bug:`1311`
 * :doc:`/plugins/permissions`: Now handles also the permissions of the
   directories. :bug:`1308` :bug:`1324`
+* Config: A new option ``-r/--redacted`` will automatically redact sensitive
+  values (e.g., passwords) when printing the config. :bug:`1376`
 
 Core changes:
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -283,6 +283,12 @@ If you want to access configuration values *outside* of your plugin's section,
 import the `config` object from the `beets` module. That is, just put ``from
 beets import config`` at the top of your plugin and access values from there.
 
+If your plugin provides configuration values for sensitive data (e.g.,
+passwords, api keys, ...), you should add these to the config so they can be
+redacted automatically when users dump their config. This can be done by
+calling ``self.config.add_redacted_fields('field1', 'field2', ..., 'fieldN')``
+in your plugin.
+
 Add Path Format Functions and Fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -340,7 +340,7 @@ config
 ``````
 ::
 
-    beet config [-pd]
+    beet config [-pdr]
     beet config -e
 
 Show or edit the user configuration. This command does one of three things:
@@ -351,6 +351,9 @@ Show or edit the user configuration. This command does one of three things:
 * The ``--path`` option instead shows the path to your configuration file.
   This can be combined with the ``--default`` flag to show where beets keeps
   its internal defaults.
+* The ``--redacted`` option will automatically mask sensitive values (e.g.,
+  passwords) when printing the configuration. This makes it easier to
+  copy/paste your config when reporting bugs.
 * With the ``--edit`` option, beets attempts to open your config file for
   editing. It first tries the ``$EDITOR`` environment variable and then a
   fallback option depending on your platform: ``open`` on OS X, ``xdg-open``

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -26,7 +26,8 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         self.config_path = os.path.join(self.temp_dir, 'config.yaml')
         with open(self.config_path, 'w') as file:
             file.write('library: lib\n')
-            file.write('option: value')
+            file.write('option: value\n')
+            file.write('password: password_value')
 
         self.cli_config_path = os.path.join(self.temp_dir, 'cli_config.yaml')
         with open(self.cli_config_path, 'w') as file:
@@ -43,12 +44,14 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
             self.run_command('config')
         output = yaml.load(output.getvalue())
         self.assertEqual(output['option'], 'value')
+        self.assertEqual(output['password'], 'password_value')
 
     def test_show_user_config_with_defaults(self):
         with capture_stdout() as output:
             self.run_command('config', '-d')
         output = yaml.load(output.getvalue())
         self.assertEqual(output['option'], 'value')
+        self.assertEqual(output['password'], 'password_value')
         self.assertEqual(output['library'], 'lib')
         self.assertEqual(output['import']['timid'], False)
 
@@ -58,6 +61,21 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         output = yaml.load(output.getvalue())
         self.assertEqual(output['library'], 'lib')
         self.assertEqual(output['option'], 'cli overwrite')
+
+    def test_show_redacted_user_config(self):
+        with capture_stdout() as output:
+            self.run_command('config', '-r')
+        output = yaml.load(output.getvalue())
+        self.assertEqual(output['option'], 'value')
+        self.assertEqual(output['password'], 'REDACTED')
+
+    def test_show_redacted_user_config_with_defaults(self):
+        with capture_stdout() as output:
+            self.run_command('config', '-rd')
+        output = yaml.load(output.getvalue())
+        self.assertEqual(output['option'], 'value')
+        self.assertEqual(output['password'], 'REDACTED')
+        self.assertEqual(output['import']['timid'], False)
 
     def test_config_paths(self):
         with capture_stdout() as output:


### PR DESCRIPTION
I think this was brought up in some issues before, as it makes it easier for people to blanket copy/paste their configuration when posting issues, without worrying about spilling their keys.

This PR introduces the `config -r` ( `config --redacted`) flag, which does the same as `config`, with the fields redacted, e.g.,

```
$ ./beet config -r
lyrics:
    sources: [lyricwiki, lyrics.com, musixmatch]
    google_API_key: REDACTED
    force: no
    auto: yes
    google_engine_ID: REDACTED
    fallback:
[...]
```

- Hard-coded a bunch of typical field names that need to be redacted (`['password', 'username', 'userid', 'apikey', apisecret', 'email']`).
- Plugins can register their own fields to be redacted, e.g.,:
`self.config.add_redacted_fields(['google_API_key', 'google_engine_ID'])`

I was considering working with regex, matching 'secret', 'key', etc, but the above list seems to cover all the fields from the plugins listed in the official beets docs.