### PR TITLE
ftintitle plugin now allows a custom format to be defined (Correct Branch)

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -117,13 +117,12 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         """Import hook for moving featuring artist automatically.
         """
         drop_feat = self.config['drop'].get(bool)
-        feat_format = self.config['format'].get(unicode)
 
         for item in task.imported_items():
-            self.ft_in_title(item, drop_feat, feat_format)
+            self.ft_in_title(item, drop_feat)
             item.store()
 
-    def update_metadata(self, item, feat_part, drop_feat, feat_format):
+    def update_metadata(self, item, feat_part, drop_feat):
         """Choose how to add new artists to the title and set the new
         metadata. Also, print out messages about any changes that are made.
         If `drop_feat` is set, then do not add the artist to the title; just
@@ -139,12 +138,13 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
         if not drop_feat and not contains_feat(item.title):
+            feat_format = self.config['format'].get(unicode)
             new_format = feat_format.format(feat_part)
             new_title = u"{0} {1}".format(item.title, new_format)
             self._log.info(u'title: {0} -> {1}', item.title, new_title)
             item.title = new_title
 
-    def ft_in_title(self, item, drop_feat, feat_format):
+    def ft_in_title(self, item, drop_feat):
         """Look for featured artists in the item's artist fields and move
         them to the title.
         """
@@ -165,6 +165,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
             # If we have a featuring artist, move it to the title.
             if feat_part:
-                self.update_metadata(item, feat_part, drop_feat, feat_format)
+                self.update_metadata(item, feat_part, drop_feat)
             else:
                 self._log.info(u'no featuring artists found')

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -82,7 +82,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'drop': False,
-            'format': u'feat. {0}'
+            'format': u'feat. {0}',
         })
 
         self._command = ui.Subcommand(

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -82,6 +82,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'drop': False,
+            'format': u'feat. {}'
         })
 
         self._command = ui.Subcommand(
@@ -116,12 +117,13 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         """Import hook for moving featuring artist automatically.
         """
         drop_feat = self.config['drop'].get(bool)
+        feat_format = self.config['format'].get(unicode)
 
         for item in task.imported_items():
-            self.ft_in_title(item, drop_feat)
+            self.ft_in_title(item, drop_feat, feat_format)
             item.store()
 
-    def update_metadata(self, item, feat_part, drop_feat):
+    def update_metadata(self, item, feat_part, drop_feat, feat_format):
         """Choose how to add new artists to the title and set the new
         metadata. Also, print out messages about any changes that are made.
         If `drop_feat` is set, then do not add the artist to the title; just
@@ -137,11 +139,12 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
         if not drop_feat and not contains_feat(item.title):
-            new_title = u"{0} feat. {1}".format(item.title, feat_part)
+            new_format = feat_format.format(feat_part)
+            new_title = u"{0} {1}".format(item.title, new_format)
             self._log.info(u'title: {0} -> {1}', item.title, new_title)
             item.title = new_title
 
-    def ft_in_title(self, item, drop_feat):
+    def ft_in_title(self, item, drop_feat, feat_format):
         """Look for featured artists in the item's artist fields and move
         them to the title.
         """
@@ -162,6 +165,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
             # If we have a featuring artist, move it to the title.
             if feat_part:
-                self.update_metadata(item, feat_part, drop_feat)
+                self.update_metadata(item, feat_part, drop_feat, feat_format)
             else:
                 self._log.info(u'no featuring artists found')

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -82,7 +82,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'drop': False,
-            'format': u'feat. {}'
+            'format': u'feat. {0}'
         })
 
         self._command = ui.Subcommand(

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -24,8 +24,8 @@ file. The available options are:
 - **drop**: Remove featured artists entirely instead of adding them to the
   title field.
   Default: ``no``.
-- **format**: Defines the format for the feat part of the new title field.
-  In this format the ``{0}`` is used to define where the featured artists are placed
+- **format**: Defines the format for the featuring X  part of the new title field.
+  In this format the ``{0}`` is used to define where the featured artists are placed.
   Default: ``feat. {0}``
 
 Running Manually

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -25,8 +25,8 @@ file. The available options are:
   title field.
   Default: ``no``.
 - **format**: Defines the format for the feat part of the new title field.
-  In this format the ``{}`` is used to define where the featured artists are placed
-  Default: ``feat. {}``
+  In this format the ``{0}`` is used to define where the featured artists are placed
+  Default: ``feat. {0}``
 
 Running Manually
 ----------------

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -24,6 +24,9 @@ file. The available options are:
 - **drop**: Remove featured artists entirely instead of adding them to the
   title field.
   Default: ``no``.
+- **format**: Defines the format for the feat part of the new title field.
+  In this format the ``{}`` is used to define where the featured artists are placed
+  Default: ``feat. {}``
 
 Running Manually
 ----------------

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -18,8 +18,64 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 from test._common import unittest
+from test.helper import TestHelper
 from beetsplug import ftintitle
 
+
+class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
+    def setUp(self):
+        """Set up configuration"""
+        self.setup_beets()
+        self.load_plugins('ftintitle')
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def _ft_add_item(self,path, artist, title, aartist):
+        return self.add_item(path=path,
+                             artist=artist,
+                             title=title,
+                             albumartist=aartist)
+
+    def _ft_set_config(self, ftformat, drop = False, auto = True):
+        self.config['ftintitle']['format'] = ftformat
+        self.config['ftintitle']['drop'] = drop
+        self.config['ftintitle']['auto'] = auto
+
+    def test_functional_drop(self):
+        item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
+        self.run_command('ftintitle', '-d')
+        item.load()
+        self.assertEqual(item['artist'], u'Alice')
+        self.assertEqual(item['title'], u'Song 1')
+
+    def test_functional_custom_format_1(self):
+        self._ft_set_config('feat. {}')
+
+        item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
+        self.run_command('ftintitle')
+        item.load()
+        self.assertEqual(item['artist'], u'Alice')
+        self.assertEqual(item['title'], u'Song 1 feat. Bob')
+
+    def test_functional_custom_format_2(self):
+        self._ft_set_config('featuring {}')
+
+        item = self._ft_add_item('/', u'Alice feat. Bob', u'Song 1', u'Alice')
+        self.run_command('ftintitle')
+        item.load()
+        self.assertEqual(item['artist'], u'Alice')
+        self.assertEqual(item['title'], u'Song 1 featuring Bob')
+
+    def test_functional_custom_format_3(self):
+        self._ft_set_config('with {}')
+
+        item = self._ft_add_item('/', u'Alice feat Bob', u'Song 1', u'Alice')
+        self.run_command('ftintitle')
+        item.load()
+        self.assertEqual(item['artist'], u'Alice')
+        self.assertEqual(item['title'], u'Song 1 with Bob')
 
 class FtInTitlePluginTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -32,13 +32,13 @@ class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
         self.unload_plugins()
         self.teardown_beets()
 
-    def _ft_add_item(self,path, artist, title, aartist):
+    def _ft_add_item(self, path, artist, title, aartist):
         return self.add_item(path=path,
                              artist=artist,
                              title=title,
                              albumartist=aartist)
 
-    def _ft_set_config(self, ftformat, drop = False, auto = True):
+    def _ft_set_config(self, ftformat, drop=False, auto=True):
         self.config['ftintitle']['format'] = ftformat
         self.config['ftintitle']['drop'] = drop
         self.config['ftintitle']['auto'] = auto
@@ -50,32 +50,28 @@ class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1')
 
-    def test_functional_custom_format_1(self):
+    def test_functional_custom_format(self):
         self._ft_set_config('feat. {}')
-
         item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1 feat. Bob')
 
-    def test_functional_custom_format_2(self):
         self._ft_set_config('featuring {}')
-
         item = self._ft_add_item('/', u'Alice feat. Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1 featuring Bob')
 
-    def test_functional_custom_format_3(self):
         self._ft_set_config('with {}')
-
         item = self._ft_add_item('/', u'Alice feat Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1 with Bob')
+
 
 class FtInTitlePluginTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -51,21 +51,21 @@ class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
         self.assertEqual(item['title'], u'Song 1')
 
     def test_functional_custom_format(self):
-        self._ft_set_config('feat. {}')
+        self._ft_set_config('feat. {0}')
         item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1 feat. Bob')
 
-        self._ft_set_config('featuring {}')
+        self._ft_set_config('featuring {0}')
         item = self._ft_add_item('/', u'Alice feat. Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()
         self.assertEqual(item['artist'], u'Alice')
         self.assertEqual(item['title'], u'Song 1 featuring Bob')
 
-        self._ft_set_config('with {}')
+        self._ft_set_config('with {0}')
         item = self._ft_add_item('/', u'Alice feat Bob', u'Song 1', u'Alice')
         self.run_command('ftintitle')
         item.load()


### PR DESCRIPTION
(Apologies for the duplicate request, but I referenced the incorrect branch. Thanks.)

I have updated the ftintitle plugin to allow a custom format to be defined. The default format is that which was previously hardcoded.

This pull request allows formats like the list below to be defined:

* feat. ...
* (Feat. ...)
* ft. ...
* featuring ...

This is my first commit to an open source project, so I'm still working my way around the beets project. Any feedback would be great.

Thanks