### PR TITLE
convert: Add 'tmpdir' option

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -125,6 +125,7 @@ class ConvertPlugin(BeetsPlugin):
             },
             u'max_bitrate': 500,
             u'auto': False,
+            u'tmpdir': None,
             u'quiet': False,
             u'embed': True,
             u'paths': {},
@@ -388,7 +389,8 @@ class ConvertPlugin(BeetsPlugin):
         fmt = self.config['format'].get(unicode).lower()
         if should_transcode(item, fmt):
             command, ext = get_format()
-            fd, dest = tempfile.mkstemp('.' + ext)
+            tmpdir = self.config['tmpdir'].get()
+            fd, dest = tempfile.mkstemp('.' + ext, dir=tmpdir)
             os.close(fd)
             _temp_files.append(dest)  # Delete the transcode later.
             try:

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -58,6 +58,8 @@ file. The available options are:
   default configuration) non-MP3 files over the maximum bitrate before adding
   them to your library.
   Default: ``no``.
+- **tmpdir**: The directory where temporary files will be stored during import.
+  Default: none (system default),
 - **copy_album_art**: Copy album art when copying or transcoding albums matched
   using the ``-a`` option. Default: ``no``.
 - **dest**: The directory where the files will be converted (or copied) to.


### PR DESCRIPTION
Closes sampsyo/beets#1382

Allows the user to specify the location where beet places temporary files during import conversion.  This allows beet to use a move operation to place the file into the beet library, as opposed to the copy/delete required when transferring into the library when it is located on an external filesystem (eg. RAID array).