### PR TITLE
Improve path query: autodetect only if the target exists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 Features:
 
+* :ref:`pathquery` are automatically triggered only if the
+  path targeted by the query exists.
 * :doc:`/plugins/duplicates` now accepts a ``--strict`` option that
   will only report duplicates if all attributes are explicitly set.
   :bug:`1000`

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -166,6 +166,8 @@ Find all items with a file modification time between 2008-12-01 and
     $ beet ls 'mtime:2008-12-01..2008-12-02'
 
 
+.. _pathquery:
+
 Path Queries
 ------------
 
@@ -175,8 +177,8 @@ Sometimes it's useful to find all the items in your library that are
     $ beet list path:/my/music/directory
 
 In fact, beets automatically recognizes any query term containing a path
-separator (``/`` on POSIX systems) as a path query, so this command is
-equivalent::
+separator (``/`` on POSIX systems) as a path query if that path exists, so this
+command is equivalent as long as ``/my/music/directory`` exist::
 
     $ beet list /my/music/directory
 


### PR DESCRIPTION
Detect path parts of a query with `PathQuery.is_path_query()` which tests for `os.sep` presence AND query part existence.

Also fix a bug where "my_path/" would not get detected: colon absence would make search for `os.sep` only happen in "my_path".

Fix #1385.