### PR TITLE
  Thread safe logging level adjustment, revisited

### DIFF
--- a/beets/logging.py
+++ b/beets/logging.py
@@ -114,6 +114,7 @@ class ThreadLocalLevelLogger(Logger):
     """
     def __init__(self, name, level=NOTSET):
         self._thread_level = threading.local()
+        self.default_level = NOTSET
         super(ThreadLocalLevelLogger, self).__init__(name, level)
 
     @property
@@ -121,13 +122,19 @@ class ThreadLocalLevelLogger(Logger):
         try:
             return self._thread_level.level
         except AttributeError:
-            self._thread_level.level = NOTSET
+            self._thread_level.level = self.default_level
             return self.level
 
     @level.setter
     def level(self, value):
         self._thread_level.level = value
 
+    def set_global_level(self, level):
+        """Set the level on the current thread + the default value for all
+        threads.
+        """
+        self.default_level = level
+        self.setLevel(level)
 
 class BeetsLogger(ThreadLocalLevelLogger, StrFormatLogger):
     pass

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -109,15 +109,12 @@ class BeetsPlugin(object):
         `base_log_level` + config options (and restore it to its previous
         value after the function returns). Also determines which params may not
         be sent for backwards-compatibility.
-
-        Note that the log level value may not be NOTSET, e.g. if a plugin
-        import stage triggers an event that is listened this very same plugin.
         """
         argspec = inspect.getargspec(func)
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            old_log_level = self._log.level
+            assert self._log.level == logging.NOTSET
             verbosity = beets.config['verbose'].get(int)
             log_level = max(logging.DEBUG, base_log_level - 10 * verbosity)
             self._log.setLevel(log_level)
@@ -133,7 +130,7 @@ class BeetsPlugin(object):
                     else:
                         raise
             finally:
-                self._log.setLevel(old_log_level)
+                self._log.setLevel(logging.NOTSET)
         return wrapper
 
     def queries(self):

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -974,9 +974,9 @@ def _configure(options):
 
     # Configure the logger.
     if config['verbose'].get(int):
-        log.setLevel(logging.DEBUG)
+        log.set_global_level(logging.DEBUG)
     else:
-        log.setLevel(logging.INFO)
+        log.set_global_level(logging.INFO)
 
     # Ensure compatibility with old (top-level) color configuration.
     # Deprecation msg to motivate user to switch to config['ui']['color].

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,8 @@ Features:
 
 Core changes:
 
+* Python 2.6 support has been dropped. This was the occasion to remove several
+  hacks and workarounds.
 * The ``tracktotal`` attribute is now a *track-level field* instead of an
   album-level one. This field stores the total number of tracks on the
   album, or if the :ref:`per_disc_numbering` config option is set, the total

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -489,8 +489,10 @@ name to make them easier to see.
 What messages will be logged depends on the logging level and the action
 performed:
 
-* On import stages and event, the default is ``WARNING`` messages.
-* On direct actions, the default is ``INFO`` and ``WARNING`` message.
+* On import stages and event handlers, the default is ``WARNING`` messages and
+  above.
+* On direct actions, the default is ``INFO`` or above, as with the rest of
+  beets.
 
 The verbosity can be increased with ``--verbose`` flags: each flags lowers the
 level by a notch.
@@ -500,4 +502,3 @@ command and an import stage, but the command needs to print more messages than
 the import stage. (For example, you'll want to log "found lyrics for this song"
 when you're run explicitly as a command, but you don't want to noisily
 interrupt the importer interface when running automatically.)
-

--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -9,13 +9,13 @@ collection better.
 Installing
 ----------
 
-You will need Python. (Beets is written for `Python 2.7`_, but it works with
-2.6 as well. Python 3.x is not yet supported.)
+You will need Python. (Beets is written for `Python 2.7`_. 2.6 support has been
+dropped, and Python 3.x is not yet supported.)
 
 .. _Python 2.7: http://www.python.org/download/
 
 * **Mac OS X** v10.7 (Lion) and 10.8 (Mountain Lion) include Python 2.7 out of
-  the box; Snow Leopard ships with Python 2.6.
+  the box; Snow Leopard ships with Python 2.6 so you will need to upgrade it.
 
 * On **Debian or Ubuntu**, depending on the version, beets is available as an
   official package (`Debian details`_, `Ubuntu details`_), so try typing:

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,6 @@ setup(
         'Environment :: Console',
         'Environment :: Web Environment',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
     ],
 )

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -23,10 +23,12 @@ class LoggingTest(TestCase):
         l3 = blog.getLogger("bar123")
         l4 = log.getLogger("bar123")
         self.assertEqual(l3, l4)
-        self.assertEqual(l3.__class__, blog.StrFormatLogger)
+        self.assertEqual(l3.__class__, blog.BeetsLogger)
+        self.assertIsInstance(l3, (blog.StrFormatLogger,
+                                   blog.ThreadLocalLevelLogger))
 
         l5 = l3.getChild("shalala")
-        self.assertEqual(l5.__class__, blog.StrFormatLogger)
+        self.assertEqual(l5.__class__, blog.BeetsLogger)
 
     def test_str_format_logging(self):
         l = blog.getLogger("baz123")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -76,8 +76,10 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.teardown_beets()
         del beetsplug.dummy
         sys.modules.pop('beetsplug.dummy')
+        self.DummyModule.DummyPlugin.listeners = None
+        self.DummyModule.DummyPlugin._raw_listeners = None
 
-    def test_command_logging(self):
+    def test_command_level0(self):
         self.config['verbose'] = 0
         with helper.capture_log() as logs:
             self.run_command('dummy')
@@ -85,15 +87,23 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertIn('dummy: info cmd', logs)
         self.assertNotIn('dummy: debug cmd', logs)
 
-        for level in (1, 2):
-            self.config['verbose'] = level
-            with helper.capture_log() as logs:
-                self.run_command('dummy')
-            self.assertIn('dummy: warning cmd', logs)
-            self.assertIn('dummy: info cmd', logs)
-            self.assertIn('dummy: debug cmd', logs)
+    def test_command_level1(self):
+        self.config['verbose'] = 1
+        with helper.capture_log() as logs:
+            self.run_command('dummy')
+        self.assertIn('dummy: warning cmd', logs)
+        self.assertIn('dummy: info cmd', logs)
+        self.assertIn('dummy: debug cmd', logs)
 
-    def test_listener_logging(self):
+    def test_command_level2(self):
+        self.config['verbose'] = 2
+        with helper.capture_log() as logs:
+            self.run_command('dummy')
+        self.assertIn('dummy: warning cmd', logs)
+        self.assertIn('dummy: info cmd', logs)
+        self.assertIn('dummy: debug cmd', logs)
+
+    def test_listener_level0(self):
         self.config['verbose'] = 0
         with helper.capture_log() as logs:
             plugins.send('dummy_event')
@@ -101,6 +111,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertNotIn('dummy: info listener', logs)
         self.assertNotIn('dummy: debug listener', logs)
 
+    def test_listener_level1(self):
         self.config['verbose'] = 1
         with helper.capture_log() as logs:
             plugins.send('dummy_event')
@@ -108,6 +119,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertIn('dummy: info listener', logs)
         self.assertNotIn('dummy: debug listener', logs)
 
+    def test_listener_level2(self):
         self.config['verbose'] = 2
         with helper.capture_log() as logs:
             plugins.send('dummy_event')
@@ -115,7 +127,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertIn('dummy: info listener', logs)
         self.assertIn('dummy: debug listener', logs)
 
-    def test_import_stage_logging(self):
+    def test_import_stage_level0(self):
         self.config['verbose'] = 0
         with helper.capture_log() as logs:
             importer = self.create_importer()
@@ -124,6 +136,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertNotIn('dummy: info import_stage', logs)
         self.assertNotIn('dummy: debug import_stage', logs)
 
+    def test_import_stage_level1(self):
         self.config['verbose'] = 1
         with helper.capture_log() as logs:
             importer = self.create_importer()
@@ -132,6 +145,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
         self.assertIn('dummy: info import_stage', logs)
         self.assertNotIn('dummy: debug import_stage', logs)
 
+    def test_import_stage_level2(self):
         self.config['verbose'] = 2
         with helper.capture_log() as logs:
             importer = self.create_importer()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, docs, flake8
+envlist = py27, pypy, docs, flake8
 
 [testenv]
 deps =
@@ -18,11 +18,6 @@ deps =
     responses
 commands =
     nosetests {posargs}
-
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    unittest2
 
 [testenv:py27cov]
 basepython = python2.7


### PR DESCRIPTION
This is another approach to the remaining logging issues (see #1320 and #1244). This supersedes PR #1366, **however this drops Python 2.6 support**. Indeed:
- it relies on `logging.Logger.level` being a property to a thread-local attribute
- properties do not work on python 2.6
- `logging.Logger` is an old-style class in python 2.6
- it cannot be made a new-style class because we dynamically patch the type of loggers to replace the logging manager (non-existent on python2.6)

Solutions include:
- dropping python 2.6 support (modification of tox.ini required)
- (just thought of it) override setLevel() instead of setting the level.