### PR TITLE
Fetchart: minwidth and enforce_ratio options

### DIFF
--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -38,9 +38,13 @@ file. The available options are:
   Default: ``cover front art album folder``.
 - **google_search**: Gather images from Google Image Search.
   Default: ``no``.
+- **minwidth**: Only images with a width bigger or equal to ``minwidth`` are
+  considered as valid album art candidates. Default: 0.
 - **maxwidth**: A maximum image width to downscale fetched images if they are
   too big. The resize operation reduces image width to at most ``maxwidth``
   pixels. The height is recomputed so that the aspect ratio is preserved.
+- **enforce_ratio**: Only images with a width:height ratio of 1:1 are
+  considered as valid album art candidates. Default: ``no``.
 - **remote_priority**: Query remote sources every time and use local image only
   as fallback.
   Default: ``no``; remote (Web) art sources are only queried if no local art is


### PR DESCRIPTION
Been wanting to get this done since quite a while now. So: 

- Minimum image width can be specified via `minwidth` (default `0`)
- The image ratio can be enforced to 1:1 using `enforce_ratio` (default `no`)


 See #1058. 

----
I haven't added changelog entry in case you wanna wait for 1.3.12.
Also: not sure how to start with tests for this. Any ideas?