### PR TITLE
Ipfs plugin

### DIFF
--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -93,13 +93,13 @@ class IPFSPlugin(BeetsPlugin):
         player.album = True
         player.play_music(jlib, player, args)
 
-    def ipfs_add(self, lib):
+    def ipfs_add(self, album):
         try:
-            album_dir = lib.item_dir()
+            album_dir = album.item_dir()
         except AttributeError:
             return False
         try:
-            if lib.ipfs:
+            if album.ipfs:
                 # Already added to ipfs
                 return False
         except AttributeError:
@@ -121,10 +121,10 @@ class IPFSPlugin(BeetsPlugin):
             if linenr == length - 1:
                 # last printed line is the album hash
                 self._log.info("album: {0}", line)
-                lib.ipfs = line
+                album.ipfs = line
             else:
                 try:
-                    item = lib.items()[linenr]
+                    item = album.items()[linenr]
                     self._log.info("item: {0}", line)
                     item.ipfs = line
                     item.store()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -118,9 +118,14 @@ class IPFSPlugin(BeetsPlugin):
 
     def ipfs_import(self, lib, _hash):
         # TODO: should be able to tag libraries, for example by nicks
-        subprocess.Popen(["ipfs", "get", _hash[0]])
-        path = os.path.dirname(lib.path) + "/" + _hash[0] + ".db"
-        shutil.move(_hash[0], path)
+        # TODO: should create a special library for all remotes, merging all
+        # entries
+        lib_root = os.path.dirname(lib.path)
+        remote_libs = lib_root + "/remotes"
+        if not os.path.exists(remote_libs):
+            os.makedirs(remote_libs)
+        path = remote_libs + "/" + _hash[0] + ".db"
+        subprocess.Popen(["ipfs", "get", _hash[0], "-o", path])
     def ipfs_added_albums(self, rlib, tmpname):
         """ Returns a new library with only albums/items added to ipfs
         """

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -18,6 +18,7 @@ from beets.plugins import BeetsPlugin
 
 import subprocess
 import shutil
+import os
 
 
 class IPFSPlugin(BeetsPlugin):
@@ -37,6 +38,9 @@ class IPFSPlugin(BeetsPlugin):
         cmd.parser.add_option('-p', '--publish', dest='publish',
                                     action='store_true',
                                     help='Publish local library to ipfs')
+        cmd.parser.add_option('-i', '--import', dest='_import',
+                                    action='store_true',
+                                    help='Import remote library from ipfs')
 
         def func(lib, opts, args):
             if opts.add:
@@ -49,6 +53,9 @@ class IPFSPlugin(BeetsPlugin):
 
             if opts.publish:
                 self.ipfs_publish(lib)
+
+            if opts._import:
+                self.ipfs_import(lib, ui.decargs(args))
 
         cmd.func = func
         return [cmd]
@@ -99,3 +106,9 @@ class IPFSPlugin(BeetsPlugin):
         _proc = subprocess.Popen(["ipfs", "add", "-q", "-p", lib.path],
                                  stdout=subprocess.PIPE)
         self._log.info("hash of library: {0}", _proc.stdout.readline())
+
+    def ipfs_import(self, lib, _hash):
+        # TODO: should be able to tag libraries, for example by nicks
+        subprocess.Popen(["ipfs", "get", _hash[0]])
+        path = os.path.dirname(lib.path) + "/" + _hash[0] + ".db"
+        shutil.move(_hash[0], path)

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -121,14 +121,19 @@ class IPFSPlugin(BeetsPlugin):
                                      stdout=subprocess.PIPE)
             self._log.info("hash of library: {0}", _proc.stdout.readline())
 
-    def ipfs_import(self, lib, _hash):
+    def ipfs_import(self, lib, args):
+        _hash = args[0]
+        if len(args) > 1:
+            lib_name = args[1]
+        else:
+            lib_name = _hash
         # TODO: should be able to tag libraries, for example by nicks
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         if not os.path.exists(remote_libs):
             os.makedirs(remote_libs)
-        path = remote_libs + "/" + _hash[0] + ".db"
-        subprocess.call(["ipfs", "get", _hash[0], "-o", path])
+        path = remote_libs + "/" + lib_name + ".db"
+        subprocess.call(["ipfs", "get", _hash, "-o", path])
 
         # add all albums from remotes into a combined library
         jpath = remote_libs + "/joined.db"

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -44,7 +44,7 @@ class IPFSPlugin(BeetsPlugin):
                                     help='Import remote library from ipfs')
         cmd.parser.add_option('-l', '--list', dest='_list',
                                     action='store_true',
-                                    help='List imported library')
+                                    help='List imported libraries')
 
         def func(lib, opts, args):
             if opts.add:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -13,7 +13,7 @@
 
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
-from beets import ui
+from beets import ui, logging
 from beets.plugins import BeetsPlugin
 
 from subprocess import call
@@ -37,27 +37,27 @@ class IPFSPlugin(BeetsPlugin):
 
         def func(lib, opts, args):
             if opts.add:
-                ipfs_add(lib.albums(ui.decargs(args)))
+                self.ipfs_add(lib.albums(ui.decargs(args)))
             if opts.get:
-                ipfs_get(lib, ui.decargs(args))
+                self.ipfs_get(lib, ui.decargs(args))
 
         cmd.func = func
         return [cmd]
 
 
-def ipfs_add(lib):
-    try:
-        album_dir = lib.get().item_dir()
-    except AttributeError:
-        return
-    ui.print_('Adding %s to ipfs' % album_dir)
-    call(["ipfs", "add", "-r", album_dir])
+    def ipfs_add(self, lib):
+        try:
+            album_dir = lib.get().item_dir()
+        except AttributeError:
+            return
+        self._log.info('Adding {0} to ipfs', album_dir)
+        call(["ipfs", "add", "-r", album_dir])
 
 
-def ipfs_get(lib, hash):
-    call(["ipfs", "get", hash[0]])
-    ui.print_('Getting %s from ipfs' % hash[0])
-    imp = ui.commands.TerminalImportSession(lib, loghandler=None,
-                                            query=None, paths=hash)
-    imp.run()
-    rmdir(hash[0])
+    def ipfs_get(self, lib, hash):
+        call(["ipfs", "get", hash[0]])
+        self._log.info('Getting {0} from ipfs', hash[0])
+        imp = ui.commands.TerminalImportSession(lib, loghandler=None,
+                                                query=None, paths=hash)
+        imp.run()
+        rmdir(hash[0])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -58,6 +58,10 @@ class IPFSPlugin(BeetsPlugin):
         def func(lib, opts, args):
             if opts.add:
                 for album in lib.albums(ui.decargs(args)):
+                    if len(album.items()) == 0:
+                        self._log.info('{0} does not contain items, aborting',
+                                       album)
+
                     self.ipfs_add(album)
                     album.store()
 
@@ -100,6 +104,7 @@ class IPFSPlugin(BeetsPlugin):
             return False
         try:
             if album.ipfs:
+                self._log.debug('{0} already added', album_dir)
                 # Already added to ipfs
                 return False
         except AttributeError:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -26,19 +26,30 @@ class IPFSPlugin(BeetsPlugin):
         cmd.parser.add_option('-a', '--add', dest='add',
                                     action='store_true',
                                     help='Add to ipfs')
+        cmd.parser.add_option('-g', '--get', dest='get',
+                                    action='store_true',
+                                    help='Get from ipfs')
 
         def func(lib, opts, args):
             if opts.add:
-                ipfs(lib.albums(ui.decargs(args)), action='add')
+                ipfs_add(lib.albums(ui.decargs(args)))
+            if opts.get:
+                ipfs_get(lib, ui.decargs(args))
 
         cmd.func = func
         return [cmd]
 
-def ipfs(lib, action):
+def ipfs_add(lib):
     try:
         album_dir = lib.get().item_dir()
     except AttributeError:
         return
-    if action == 'add':
-        ui.print_('Adding %s to ipfs' % album_dir)
-        call(["ipfs", "add", "-r", album_dir])
+    ui.print_('Adding %s to ipfs' % album_dir)
+    call(["ipfs", "add", "-r", album_dir])
+
+def ipfs_get(lib, hash):
+    call(["ipfs", "get", hash[0]])
+    ui.print_('Getting %s from ipfs' % hash[0])
+    imp = ui.commands.TerminalImportSession(lib,loghandler=None,
+                                            query=None, paths=hash)
+    imp.run()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -1,0 +1,44 @@
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from beets import ui
+from beets.plugins import BeetsPlugin
+
+from subprocess import call
+
+class IPFSPlugin(BeetsPlugin):
+    def __init__(self):
+        super(IPFSPlugin, self).__init__()
+
+    def commands(self):
+        cmd = ui.Subcommand('ipfs',
+                            help='interact with ipfs')
+        cmd.parser.add_option('-a', '--add', dest='add',
+                                    action='store_true',
+                                    help='Add to ipfs')
+
+        def func(lib, opts, args):
+            if opts.add:
+                ipfs(lib.albums(ui.decargs(args)), action='add')
+
+        cmd.func = func
+        return [cmd]
+
+def ipfs(lib, action):
+    try:
+        album_dir = lib.get().item_dir()
+    except AttributeError:
+        return
+    if action == 'add':
+        ui.print_('Adding %s to ipfs' % album_dir)
+        call(["ipfs", "add", "-r", album_dir])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -11,6 +11,8 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+"""Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
+"""
 from beets import ui
 from beets.plugins import BeetsPlugin
 

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -195,13 +195,14 @@ class IPFSPlugin(BeetsPlugin):
                 self._log.error(msg)
                 return False
         path = remote_libs + "/" + lib_name + ".db"
-        cmd = "ipfs get {0} -o".format(_hash).split()
-        cmd.append(path)
-        try:
-            util.command_output(cmd)
-        except (OSError, subprocess.CalledProcessError):
-            self._log.error("Could not import {0}".format(_hash))
-            return False
+        if not os.path.exists(path):
+            cmd = "ipfs get {0} -o".format(_hash).split()
+            cmd.append(path)
+            try:
+                util.command_output(cmd)
+            except (OSError, subprocess.CalledProcessError):
+                self._log.error("Could not import {0}".format(_hash))
+                return False
 
         # add all albums from remotes into a combined library
         jpath = remote_libs + "/joined.db"

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -262,9 +262,10 @@ class IPFSPlugin(BeetsPlugin):
             item.path = '/ipfs/{0}/{1}'.format(album.ipfs,
                                                os.path.basename(item.path))
 
-            tmplib.add(item)
-            item.store()
+            item.id = None
             items.append(item)
+        if len(items) < 1:
+            return False
         self._log.info("Adding '{0}' to temporary library", album)
         new_album = tmplib.add_album(items)
         new_album.ipfs = album.ipfs

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -52,10 +52,10 @@ class IPFSPlugin(BeetsPlugin):
         self._log.info('Adding {0} to ipfs', album_dir)
         call(["ipfs", "add", "-r", album_dir])
 
-    def ipfs_get(self, lib, hash):
-        call(["ipfs", "get", hash[0]])
-        self._log.info('Getting {0} from ipfs', hash[0])
+    def ipfs_get(self, lib, _hash):
+        call(["ipfs", "get", _hash[0]])
+        self._log.info('Getting {0} from ipfs', _hash[0])
         imp = ui.commands.TerminalImportSession(lib, loghandler=None,
-                                                query=None, paths=hash)
+                                                query=None, paths=_hash)
         imp.run()
-        rmdir(hash[0])
+        rmdir(_hash[0])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -26,6 +26,12 @@ class IPFSPlugin(BeetsPlugin):
 
     def __init__(self):
         super(IPFSPlugin, self).__init__()
+        self.config.add({
+            'auto': True,
+        })
+
+        if self.config['auto']:
+            self.import_stages = [self.auto_add]
 
     def commands(self):
         cmd = ui.Subcommand('ipfs',
@@ -72,6 +78,11 @@ class IPFSPlugin(BeetsPlugin):
 
         cmd.func = func
         return [cmd]
+
+    def auto_add(self, session, task):
+        if task.is_album:
+            self.ipfs_add(task.album)
+            task.album.store()
 
     def ipfs_play(self, lib, opts, args):
         from beetsplug.play import PlayPlugin

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -162,19 +162,21 @@ class IPFSPlugin(BeetsPlugin):
 
     def ipfs_list(self, lib, args):
         fmt = config['format_album'].get()
-        albums = self.query(lib, args)
-        if albums:
-            for album in albums:
-                ui.print_(format(album, fmt), " : ", album.ipfs)
-        else:
-            ui.print_("No imported albums yet.")
+        try:
+            albums = self.query(lib, args)
+        except IOError:
+            ui.print_("No imported libraries yet.")
+            return
+
+        for album in albums:
+            ui.print_(format(album, fmt), " : ", album.ipfs)
 
     def query(self, lib, args):
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         path = remote_libs + "/joined.db"
         if not os.path.isfile(path):
-            return False
+            raise IOError
         rlib = library.Library(path)
         albums = rlib.albums(ui.decargs(args))
         return albums

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -110,7 +110,7 @@ class IPFSPlugin(BeetsPlugin):
     def ipfs_publish(self, lib):
         # TODO: strip local paths from library before publishing
         with tempfile.NamedTemporaryFile() as tmp:
-            ipfs_lib = self.ipfs_added_albums(lib, tmp.name)
+            self.ipfs_added_albums(lib, tmp.name)
             _proc = subprocess.Popen(["ipfs", "add", "-q", tmp.name],
                                      stdout=subprocess.PIPE)
             self._log.info("hash of library: {0}", _proc.stdout.readline())

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -82,7 +82,7 @@ class IPFSPlugin(BeetsPlugin):
 
         for linenr, line in enumerate(all_lines):
             line = line.strip()
-            if linenr == length-1:
+            if linenr == length - 1:
                 # last printed line is the album hash
                 self._log.info("album: {0}", line)
                 lib.ipfs = line

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -152,14 +152,18 @@ class IPFSPlugin(BeetsPlugin):
         return False
 
     def ipfs_list(self, lib, args):
+        fmt = config['format_album'].get()
+        albums = self.query(lib, args)
+        for album in albums:
+            ui.print_(format(album, fmt), " : ", album.ipfs)
+
+    def query(self, lib, args):
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         path = remote_libs + "/joined.db"
         rlib = library.Library(path)
         albums = rlib.albums(ui.decargs(args))
-        fmt = config['format_album'].get()
-        for album in albums:
-            ui.print_(format(album, fmt), " : ", album.ipfs)
+        return albums
 
     def ipfs_added_albums(self, rlib, tmpname):
         """ Returns a new library with only albums/items added to ipfs

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -13,7 +13,7 @@
 
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
-from beets import ui, library
+from beets import ui, library, config
 from beets.plugins import BeetsPlugin
 
 import subprocess
@@ -42,6 +42,9 @@ class IPFSPlugin(BeetsPlugin):
         cmd.parser.add_option('-i', '--import', dest='_import',
                                     action='store_true',
                                     help='Import remote library from ipfs')
+        cmd.parser.add_option('-l', '--list', dest='_list',
+                                    action='store_true',
+                                    help='List imported library')
 
         def func(lib, opts, args):
             if opts.add:
@@ -57,6 +60,9 @@ class IPFSPlugin(BeetsPlugin):
 
             if opts._import:
                 self.ipfs_import(lib, ui.decargs(args))
+
+            if opts._list:
+                self.ipfs_list(lib, ui.decargs(args))
 
         cmd.func = func
         return [cmd]
@@ -140,6 +146,17 @@ class IPFSPlugin(BeetsPlugin):
             if jalbum.mb_albumid == check.mb_albumid:
                 return True
         return False
+
+    def ipfs_list(self, lib, args):
+        lib_root = os.path.dirname(lib.path)
+        remote_libs = lib_root + "/remotes"
+        path = remote_libs + "/joined.db"
+        rlib = library.Library(path)
+        albums = rlib.albums(ui.decargs(args))
+        fmt = config['format_album'].get()
+        for album in albums:
+            ui.print_(format(album, fmt), " : ", album.ipfs)
+
     def ipfs_added_albums(self, rlib, tmpname):
         """ Returns a new library with only albums/items added to ipfs
         """

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -13,7 +13,7 @@
 
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
-from beets import ui, logging
+from beets import ui
 from beets.plugins import BeetsPlugin
 
 from subprocess import call

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -47,7 +47,7 @@ class IPFSPlugin(BeetsPlugin):
                                     help='Query imported libraries')
         cmd.parser.add_option('-m', '--play', dest='play',
                                     action='store_true',
-                                    help='Play music remote libraries')
+                                    help='Play music from remote libraries')
 
         def func(lib, opts, args):
             if opts.add:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -81,8 +81,8 @@ class IPFSPlugin(BeetsPlugin):
 
     def auto_add(self, session, task):
         if task.is_album:
-            self.ipfs_add(task.album)
-            task.album.store()
+            if self.ipfs_add(task.album):
+                task.album.store()
 
     def ipfs_play(self, lib, opts, args):
         from beetsplug.play import PlayPlugin
@@ -97,7 +97,14 @@ class IPFSPlugin(BeetsPlugin):
         try:
             album_dir = lib.item_dir()
         except AttributeError:
-            return
+            return False
+        try:
+            if lib.ipfs:
+                # Already added to ipfs
+                return False
+        except AttributeError:
+            pass
+
         self._log.info('Adding {0} to ipfs', album_dir)
 
         cmd = "ipfs add -q -r".split()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -15,6 +15,7 @@ from beets import ui
 from beets.plugins import BeetsPlugin
 
 from subprocess import call
+from os import rmdir
 
 
 class IPFSPlugin(BeetsPlugin):
@@ -57,3 +58,4 @@ def ipfs_get(lib, hash):
     imp = ui.commands.TerminalImportSession(lib, loghandler=None,
                                             query=None, paths=hash)
     imp.run()
+    rmdir(hash[0])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -127,7 +127,6 @@ class IPFSPlugin(BeetsPlugin):
             lib_name = args[1]
         else:
             lib_name = _hash
-        # TODO: should be able to tag libraries, for example by nicks
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         if not os.path.exists(remote_libs):

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -16,7 +16,7 @@
 from beets import ui
 from beets.plugins import BeetsPlugin
 
-from subprocess import call
+import subprocess
 from os import rmdir
 
 
@@ -50,10 +50,17 @@ class IPFSPlugin(BeetsPlugin):
         except AttributeError:
             return
         self._log.info('Adding {0} to ipfs', album_dir)
-        call(["ipfs", "add", "-r", album_dir])
+        subprocess.call(["ipfs", "add", "-r", album_dir])
 
     def ipfs_get(self, lib, _hash):
-        call(["ipfs", "get", _hash[0]])
+        try:
+            subprocess.check_output(["ipfs", "get", _hash[0]],
+                                    stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as err:
+            self._log.error('Failed to get {0} from ipfs.\n{1}',
+                            _hash[0], err.output)
+            return False
+
         self._log.info('Getting {0} from ipfs', _hash[0])
         imp = ui.commands.TerminalImportSession(lib, loghandler=None,
                                                 query=None, paths=_hash)

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -63,12 +63,12 @@ class IPFSPlugin(BeetsPlugin):
             if line != '':
                 if count < len(lib.items()):
                     item = lib.items()[count]
-                    print "item:: %s" % line
+                    self._log.info("item: {0}", line)
                     item.ipfs = line
                     item.store()
                     count += 1
                 else:
-                    print "album:: %s" % line
+                    self._log.info("album: {0}", line)
                     lib.ipfs = line
             else:
                 break

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -210,9 +210,13 @@ class IPFSPlugin(BeetsPlugin):
         nlib = library.Library(path)
         for album in nlib.albums():
             if not self.already_added(album, jlib):
+                new_album = []
                 for item in album.items():
-                    jlib.add(item)
-                jlib.add(album)
+                    item.id = None
+                    new_album.append(item)
+                added_album = jlib.add_album(new_album)
+                added_album.ipfs = album.ipfs
+                added_album.store()
 
     def already_added(self, check, jlib):
         for jalbum in jlib.albums():

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -17,7 +17,7 @@ from beets import ui
 from beets.plugins import BeetsPlugin
 
 import subprocess
-from os import rmdir
+import shutil
 
 
 class IPFSPlugin(BeetsPlugin):
@@ -87,4 +87,4 @@ class IPFSPlugin(BeetsPlugin):
         imp = ui.commands.TerminalImportSession(lib, loghandler=None,
                                                 query=None, paths=_hash)
         imp.run()
-        rmdir(_hash[0])
+        shutil.rmtree(_hash[0])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -44,7 +44,7 @@ class IPFSPlugin(BeetsPlugin):
                                     help='Import remote library from ipfs')
         cmd.parser.add_option('-l', '--list', dest='_list',
                                     action='store_true',
-                                    help='List imported libraries')
+                                    help='Query imported libraries')
 
         def func(lib, opts, args):
             if opts.add:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -165,7 +165,12 @@ class IPFSPlugin(BeetsPlugin):
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         if not os.path.exists(remote_libs):
-            os.makedirs(remote_libs)
+            try:
+                os.makedirs(remote_libs)
+            except OSError as e:
+                msg = "Could not create {0}. Error: {1}".format(remote_libs, e)
+                self._log.error(msg)
+                return False
         path = remote_libs + "/" + lib_name + ".db"
         cmd = "ipfs get {0} -o".format(_hash).split()
         cmd.append(path)

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -44,7 +44,6 @@ class IPFSPlugin(BeetsPlugin):
         cmd.func = func
         return [cmd]
 
-
     def ipfs_add(self, lib):
         try:
             album_dir = lib.get().item_dir()
@@ -52,7 +51,6 @@ class IPFSPlugin(BeetsPlugin):
             return
         self._log.info('Adding {0} to ipfs', album_dir)
         call(["ipfs", "add", "-r", album_dir])
-
 
     def ipfs_get(self, lib, hash):
         call(["ipfs", "get", hash[0]])

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -230,7 +230,6 @@ class IPFSPlugin(BeetsPlugin):
     def create_new_album(self, album, tmplib):
         items = []
         for item in album.items():
-            print item
             try:
                 if not item.ipfs:
                     break
@@ -238,7 +237,7 @@ class IPFSPlugin(BeetsPlugin):
                 pass
             # Clear current path from item
             item.path = '/ipfs/{0}/{1}'.format(album.ipfs,
-                                                os.path.basename(item.path))
+                                               os.path.basename(item.path))
 
             tmplib.add(item)
             item.store()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -222,19 +222,28 @@ class IPFSPlugin(BeetsPlugin):
         for album in rlib.albums():
             try:
                 if album.ipfs:
-                    items = []
-                    for item in album.items():
-                        # Clear current path from item
-                        item.path = '/ipfs/{0}/{1}'.format(album.ipfs,
-                                                           os.path.basename(item.path))
-
-                        tmplib.add(item)
-                        item.store()
-                        items.append(item)
-                    self._log.info("Adding '{0}' to temporary library", album)
-                    new_album = tmplib.add_album(items)
-                    new_album.ipfs = album.ipfs
-                    new_album.store()
+                    self.create_new_album(album, tmplib)
             except AttributeError:
                 pass
         return tmplib
+
+    def create_new_album(self, album, tmplib):
+        items = []
+        for item in album.items():
+            print item
+            try:
+                if not item.ipfs:
+                    break
+            except AttributeError:
+                pass
+            # Clear current path from item
+            item.path = '/ipfs/{0}/{1}'.format(album.ipfs,
+                                                os.path.basename(item.path))
+
+            tmplib.add(item)
+            item.store()
+            items.append(item)
+        self._log.info("Adding '{0}' to temporary library", album)
+        new_album = tmplib.add_album(items)
+        new_album.ipfs = album.ipfs
+        new_album.store()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -178,7 +178,7 @@ class IPFSPlugin(BeetsPlugin):
         if not os.path.isfile(path):
             raise IOError
         rlib = library.Library(path)
-        albums = rlib.albums(ui.decargs(args))
+        albums = rlib.albums(args)
         return albums
 
     def ipfs_added_albums(self, rlib, tmpname):

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -34,6 +34,9 @@ class IPFSPlugin(BeetsPlugin):
         cmd.parser.add_option('-g', '--get', dest='get',
                                     action='store_true',
                                     help='Get from ipfs')
+        cmd.parser.add_option('-p', '--publish', dest='publish',
+                                    action='store_true',
+                                    help='Publish local library to ipfs')
 
         def func(lib, opts, args):
             if opts.add:
@@ -43,6 +46,9 @@ class IPFSPlugin(BeetsPlugin):
 
             if opts.get:
                 self.ipfs_get(lib, ui.decargs(args))
+
+            if opts.publish:
+                self.ipfs_publish(lib)
 
         cmd.func = func
         return [cmd]
@@ -88,3 +94,8 @@ class IPFSPlugin(BeetsPlugin):
                                                 query=None, paths=_hash)
         imp.run()
         shutil.rmtree(_hash[0])
+
+    def ipfs_publish(self, lib):
+        _proc = subprocess.Popen(["ipfs", "add", "-q", "-p", lib.path],
+                         stdout=subprocess.PIPE)
+        self._log.info("hash of library: {0}", _proc.stdout.readline())

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -115,7 +115,6 @@ class IPFSPlugin(BeetsPlugin):
         shutil.rmtree(_hash[0])
 
     def ipfs_publish(self, lib):
-        # TODO: strip local paths from library before publishing
         with tempfile.NamedTemporaryFile() as tmp:
             self.ipfs_added_albums(lib, tmp.name)
             _proc = subprocess.Popen(["ipfs", "add", "-q", tmp.name],
@@ -165,7 +164,10 @@ class IPFSPlugin(BeetsPlugin):
             try:
                 if album.ipfs:
                     for item in album.items():
+                        # Clear current path from item
+                        item.path = ''
                         tmplib.add(item)
+                    album.artpath = ''
                     tmplib.add(album)
             except AttributeError:
                 pass

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -163,13 +163,18 @@ class IPFSPlugin(BeetsPlugin):
     def ipfs_list(self, lib, args):
         fmt = config['format_album'].get()
         albums = self.query(lib, args)
-        for album in albums:
-            ui.print_(format(album, fmt), " : ", album.ipfs)
+        if albums:
+            for album in albums:
+                ui.print_(format(album, fmt), " : ", album.ipfs)
+        else:
+            ui.print_("No imported albums yet.")
 
     def query(self, lib, args):
         lib_root = os.path.dirname(lib.path)
         remote_libs = lib_root + "/remotes"
         path = remote_libs + "/joined.db"
+        if not os.path.isfile(path):
+            return False
         rlib = library.Library(path)
         albums = rlib.albums(ui.decargs(args))
         return albums

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -97,5 +97,5 @@ class IPFSPlugin(BeetsPlugin):
 
     def ipfs_publish(self, lib):
         _proc = subprocess.Popen(["ipfs", "add", "-q", "-p", lib.path],
-                         stdout=subprocess.PIPE)
+                                 stdout=subprocess.PIPE)
         self._log.info("hash of library: {0}", _proc.stdout.readline())

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -210,6 +210,7 @@ class IPFSPlugin(BeetsPlugin):
                         item.path = ''
                         tmplib.add(item)
                     album.artpath = ''
+                    self._log.info("Adding '{0}' to temporary library", album)
                     tmplib.add(album)
             except AttributeError:
                 pass

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -16,7 +16,9 @@ from beets.plugins import BeetsPlugin
 
 from subprocess import call
 
+
 class IPFSPlugin(BeetsPlugin):
+
     def __init__(self):
         super(IPFSPlugin, self).__init__()
 
@@ -39,6 +41,7 @@ class IPFSPlugin(BeetsPlugin):
         cmd.func = func
         return [cmd]
 
+
 def ipfs_add(lib):
     try:
         album_dir = lib.get().item_dir()
@@ -47,9 +50,10 @@ def ipfs_add(lib):
     ui.print_('Adding %s to ipfs' % album_dir)
     call(["ipfs", "add", "-r", album_dir])
 
+
 def ipfs_get(lib, hash):
     call(["ipfs", "get", hash[0]])
     ui.print_('Getting %s from ipfs' % hash[0])
-    imp = ui.commands.TerminalImportSession(lib,loghandler=None,
+    imp = ui.commands.TerminalImportSession(lib, loghandler=None,
                                             query=None, paths=hash)
     imp.run()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -75,6 +75,7 @@ class IPFSPlugin(BeetsPlugin):
         length = len(all_lines)
 
         for linenr, line in enumerate(all_lines):
+            line = line.strip()
             if linenr == length-1:
                 # last printed line is the album hash
                 self._log.info("album: {0}", line)

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -50,6 +50,7 @@ Each plugin has its own set of options that can be defined in a section bearing 
    importfeeds
    info
    inline
+   ipfs
    keyfinder
    lastgenre
    lastimport
@@ -128,6 +129,7 @@ Interoperability
 ----------------
 
 * :doc:`importfeeds`: Keep track of imported files via ``.m3u`` playlist file(s) or symlinks.
+* :doc:`ipfs`: Import libraries from friends and get albums from them via ipfs.
 * :doc:`mpdupdate`: Automatically notifies `MPD`_ whenever the beets library
   changes.
 * :doc:`play`: Play beets queries in your music player.

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -22,11 +22,12 @@ Usage
 To add albums to ipfs, making them shareable, use the -a or --add flag. If used
 without arguments it will add all albums in the local library.  When added all
 items and albums will get a ipfs entry in the database containing the hash of
-that specific file/folder.
+that specific file/folder. Newly imported albums will be added automatically to
+ipfs unless set not to do so, see the configuration section below.
 
 These hashes can then be given to a friend and they can ``get`` that album from
 ipfs and import it to beets using the -g or --get flag.
-If the argument passed to the -g flag isn't a ipfs hash it'll be used as a
+If the argument passed to the -g flag isn't an ipfs hash it'll be used as a
 query instead, getting all albums matching the query.
 
 Using the -p or --publish flag a copy of the local library will be
@@ -48,3 +49,10 @@ Ipfs can be mounted as a FUSE file system. This means that music in a remote
 library can be streamed directly, without importing them to the local library
 first. If the /ipfs folder is mounted then matching queries will be sent to the
 :doc:`/plugins/play` using the -m or --play flag.
+
+Configuration
+-------------
+
+The ipfs plugin will automatically add imported albums to ipfs and add those hashes
+to the database. This can be turned off by setting the ``auto`` option in the
+ipfs section of the config to ``no``.

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -1,0 +1,44 @@
+IPFS Plugin
+===========
+
+The ``ipfs`` plugin makes it easy to share your library and music with friends.
+The plugin uses `ipfs`_ for storing the libraries and the file content.
+
+.. _ipfs: http://ipfs.io/
+
+Installation
+------------
+
+This plugin requires `go-ipfs`_ running as a dameon and that the ipfs command is
+in the users $PATH.
+
+.. _go-ipfs: https://github.com/ipfs/go-ipfs
+
+Enable the ``ipfs`` plugin in your configuration (see :ref:`using-plugins`).
+
+Usage
+-----
+
+To add albums to ipfs, making them shareable, use the -a or --add flag. If used
+without arguments it will add all albums in the local library.  When added all
+items and albums will get a ipfs entry in the database containing the hash of
+that specific file/folder.
+
+These hashes can then be given to a friend and they can ``get`` that album from
+ipfs and import it to beets using the -g or --get flag.
+
+Using the -p or --publish flag a copy of the local library will be
+published to ipfs. Only albums/items with ipfs records in the database will
+published, and local paths will be stripped from the library. A hash of the
+library will be returned to the user.
+
+A friend can then import this remote library by using the -i or --import flag.
+To tag an imported library with a specific name by passing a name as the second
+argument to -i, after the hash.
+The content of all remote libraries will be combined into an additional library
+as long as the content doesn't already exist in the joined library.
+
+When remote libraries has been imported you can search them by using the -l or
+--list flag. The hash of albums matching the query will be returned, this can
+then be used with -g to fetch and import the album to the local library.
+

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -26,6 +26,8 @@ that specific file/folder.
 
 These hashes can then be given to a friend and they can ``get`` that album from
 ipfs and import it to beets using the -g or --get flag.
+If the argument passed to the -g flag isn't a ipfs hash it'll be used as a
+query instead, getting all albums matching the query.
 
 Using the -p or --publish flag a copy of the local library will be
 published to ipfs. Only albums/items with ipfs records in the database will

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -9,7 +9,7 @@ The plugin uses `ipfs`_ for storing the libraries and the file content.
 Installation
 ------------
 
-This plugin requires `go-ipfs`_ running as a dameon and that the ipfs command is
+This plugin requires `go-ipfs`_ running as a daemon and that the ipfs command is
 in the users $PATH.
 
 .. _go-ipfs: https://github.com/ipfs/go-ipfs

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -44,3 +44,7 @@ When remote libraries has been imported you can search them by using the -l or
 --list flag. The hash of albums matching the query will be returned, this can
 then be used with -g to fetch and import the album to the local library.
 
+Ipfs can be mounted as a FUSE file system. This means that music in a remote
+library can be streamed directly, without importing them to the local library
+first. If the /ipfs folder is mounted then matching queries will be sent to the
+:doc:`/plugins/play` using the -m or --play flag.

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -1,0 +1,94 @@
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from mock import patch
+
+from beets import library
+from beetsplug.ipfs import IPFSPlugin
+
+from test import _common
+from test._common import unittest
+from test.helper import TestHelper
+import os
+
+
+class IPFSPluginTest(unittest.TestCase, TestHelper):
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('ipfs')
+        self.patcher = patch('beets.util.command_output')
+        self.command_output = self.patcher.start()
+        self.lib = library.Library(":memory:")
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+        self.patcher.stop()
+
+    def test_stored_hashes(self):
+        test_album = self.mk_test_album()
+        ipfs = IPFSPlugin()
+        added_albums = ipfs.ipfs_added_albums(self.lib, self.lib.path)
+        added_album = added_albums.get_album(1)
+        self.assertEqual(added_album.ipfs, test_album.ipfs)
+        found = False
+        want_item = test_album.items()[2]
+        for check_item in added_album.items():
+            try:
+                if check_item.ipfs:
+                    want_path = '/ipfs/{0}/{1}'.format(test_album.ipfs,
+                                                       os.path.basename(
+                                                           want_item.path))
+                    self.assertEqual(check_item.path, want_path)
+                    self.assertEqual(check_item.ipfs, want_item.ipfs)
+                    self.assertEqual(check_item.title, want_item.title)
+                    found = True
+            except AttributeError:
+                pass
+        self.assertTrue(found)
+
+    def mk_test_album(self):
+        items = [_common.item() for _ in range(3)]
+        items[0].title = 'foo bar'
+        items[0].artist = 'one'
+        items[0].album = 'baz'
+        items[0].year = 2001
+        items[0].comp = True
+        items[1].title = 'baz qux'
+        items[1].artist = 'two'
+        items[1].album = 'baz'
+        items[1].year = 2002
+        items[1].comp = True
+        items[2].title = 'beets 4 eva'
+        items[2].artist = 'three'
+        items[2].album = 'foo'
+        items[2].year = 2003
+        items[2].comp = False
+        items[2].ipfs = 'QmfM9ic5LJj7V6ecozFx1MkSoaaiq3PXfhJoFvyqzpLXSk'
+
+        for item in items:
+            self.lib.add(item)
+
+        album = self.lib.add_album(items)
+        album.ipfs = "QmfM9ic5LJj7V6ecozFx1MkSoaaiq3PXfhJoFvyqzpLXSf"
+        album.store()
+
+        return album
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == b'__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
http://ipfs.io or https://github.com/ipfs/go-ipfs is a global, versioned, peer-to-peer filesystem.
This plugin is so far extremely rough, but it adds the option to add or get albums from ipfs.
So if i have an album in my library I can do
```beets ipfs -a [query]```
This will return individual hashes for all the albums files as well as a hash for the whole album.
I can then, in another library without this album, run
```beets ipfs -g [hash]```
and the album will be downloaded from ipfs and imported to the library.

Again, this is a very rough demo, so it's not merge:able yet. But i'd be interesting to hear what you think.