### PR TITLE
Use comma as "or" operator for queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@ New features:
 * :doc:`/plugins/fetchart`: new settings `minwidth` and `enforce_ratio`
   to put restrictions (min width in pixels, and 1:1 image ratio, resp.)
   for valid album art candidates. :bug:`1394`
+* Queries can take the "OR"-operator in the form of a comma, e.g.,
+  ``beet ls foo , bar`` to get all items matching `foo` or matching `bar`.
+  :bug:`1423`
 
 Little fixes and improvements:
 

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -37,6 +37,15 @@ my library. It *doesn't* match other songs by the Magnetic Fields, nor does it
 match "Tomorrowland" by Walter Meego---those songs only have *one* of the two
 keywords I specified.
 
+Keywords can also be joined with a Boolean "or" using a comma. For example,
+the command::
+
+    $ beet ls magnetic tomorrow , beatles yesterday
+
+will match both "The House of Tomorrow" by the Magnetic Fields, as well as
+"Yesterday" by The Beatles. Note that the comma has to be followed by a space
+(e.g., ``foo,bar`` will be treated as a single keyword, *not* as an OR-query).
+
 Specific Fields
 ---------------
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -475,6 +475,46 @@ class SortFromStringsTest(unittest.TestCase):
         self.assertIsInstance(s, TestSort)
 
 
+class ParseSortedQueryTest(unittest.TestCase):
+    def psq(self, parts):
+        return dbcore.parse_sorted_query(
+            TestModel1,
+            parts
+        )
+
+    def test_and_query(self):
+        q, s = self.psq([u'foo', u'bar'])
+        self.assertIsInstance(q, dbcore.query.AndQuery)
+        self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(len(q.subqueries), 2)
+
+    def test_or_query(self):
+        q, s = self.psq([u'foo', u',', u'bar'])
+        self.assertIsInstance(q, dbcore.query.OrQuery)
+        self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(len(q.subqueries), 2)
+
+    def test_no_space_before_comma_or_query(self):
+        # E.g., query `foo, bar`
+        q, s = self.psq([u'foo,', u'bar'])
+        self.assertIsInstance(q, dbcore.query.OrQuery)
+        self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(len(q.subqueries), 2)
+
+    def test_no_spaces_or_query(self):
+        # E.g., query `foo, bar`
+        q, s = self.psq([u'foo,bar'])
+        self.assertIsInstance(q, dbcore.query.AndQuery)
+        self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(len(q.subqueries), 1)
+
+    def test_trailing_comma_or_query(self):
+        q, s = self.psq([u'foo', u',', u'bar', u','])
+        self.assertIsInstance(q, dbcore.query.OrQuery)
+        self.assertIsInstance(s, dbcore.query.NullSort)
+        self.assertEqual(len(q.subqueries), 3)
+
+
 class ResultsIteratorTest(unittest.TestCase):
     def setUp(self):
         self.db = TestDatabase1(':memory:')


### PR DESCRIPTION
Scan the query parts for commas (`u','`) and treat these as (sub) `AndQuery`s
that need to be wrapped in an `OrQuery` (if there are more than one).

Supports `foo, bar` and `foo , bar`. 

See #976
