### PR TITLE
Sort can ignore case if configured to do so

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -67,6 +67,7 @@ time_format: '%Y-%m-%d %H:%M:%S'
 
 sort_album: albumartist+ album+
 sort_item: artist+ album+ disc+ track+
+sort_ignore_case: no
 
 paths:
     default: $albumartist/$album%aunique{}/$track $title

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -67,7 +67,7 @@ time_format: '%Y-%m-%d %H:%M:%S'
 
 sort_album: albumartist+ album+
 sort_item: artist+ album+ disc+ track+
-sort_ignore_case: no
+sort_case_insensitive: yes
 
 paths:
     default: $albumartist/$album%aunique{}/$track $title

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -717,10 +717,10 @@ class FieldSort(Sort):
     """An abstract sort criterion that orders by a specific field (of
     any kind).
     """
-    def __init__(self, field, ascending=True, ignore_case=False):
+    def __init__(self, field, ascending=True, case_insensitive=True):
         self.field = field
         self.ascending = ascending
-        self.ignore_case = ignore_case
+        self.case_insensitive = case_insensitive
 
     def sort(self, objs):
         # TODO: Conversion and null-detection here. In Python 3,
@@ -729,7 +729,7 @@ class FieldSort(Sort):
 
         def key(item):
             field_val = getattr(item, self.field)
-            if self.ignore_case and isinstance(field_val, unicode):
+            if self.case_insensitive and isinstance(field_val, unicode):
                 field_val = field_val.lower()
             return field_val
 
@@ -756,7 +756,7 @@ class FixedFieldSort(FieldSort):
     """
     def order_clause(self):
         order = "ASC" if self.ascending else "DESC"
-        collate = 'COLLATE NOCASE' if self.ignore_case else ''
+        collate = 'COLLATE NOCASE' if self.case_insensitive else ''
         return "{0} {1} {2}".format(self.field, collate, order)
 
 

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -19,7 +19,7 @@ from __future__ import division, absolute_import, print_function
 import re
 import itertools
 from . import query
-
+import beets
 
 PARSE_QUERY_PART_REGEX = re.compile(
     # Non-capturing optional segment for the keyword.
@@ -138,13 +138,14 @@ def construct_sort_part(model_cls, part):
     assert direction in ('+', '-'), "part must end with + or -"
     is_ascending = direction == '+'
 
+    ignore_case = beets.config['sort_ignore_case'].get(bool)
     if field in model_cls._sorts:
-        sort = model_cls._sorts[field](model_cls, is_ascending)
+        sort = model_cls._sorts[field](model_cls, is_ascending, ignore_case)
     elif field in model_cls._fields:
-        sort = query.FixedFieldSort(field, is_ascending)
+        sort = query.FixedFieldSort(field, is_ascending, ignore_case)
     else:
         # Flexible or computed.
-        sort = query.SlowFieldSort(field, is_ascending)
+        sort = query.SlowFieldSort(field, is_ascending, ignore_case)
     return sort
 
 

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -138,14 +138,15 @@ def construct_sort_part(model_cls, part):
     assert direction in ('+', '-'), "part must end with + or -"
     is_ascending = direction == '+'
 
-    ignore_case = beets.config['sort_ignore_case'].get(bool)
+    case_insensitive = beets.config['sort_case_insensitive'].get(bool)
     if field in model_cls._sorts:
-        sort = model_cls._sorts[field](model_cls, is_ascending, ignore_case)
+        sort = model_cls._sorts[field](model_cls, is_ascending,
+                                       case_insensitive)
     elif field in model_cls._fields:
-        sort = query.FixedFieldSort(field, is_ascending, ignore_case)
+        sort = query.FixedFieldSort(field, is_ascending, case_insensitive)
     else:
         # Flexible or computed.
-        sort = query.SlowFieldSort(field, is_ascending, ignore_case)
+        sort = query.SlowFieldSort(field, is_ascending, case_insensitive)
     return sort
 
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -197,15 +197,15 @@ class SmartArtistSort(dbcore.query.Sort):
     """Sort by artist (either album artist or track artist),
     prioritizing the sort field over the raw field.
     """
-    def __init__(self, model_cls, ascending=True, ignore_case=False):
+    def __init__(self, model_cls, ascending=True, case_insensitive=True):
         self.album = model_cls is Album
         self.ascending = ascending
-        self.ignore_case = ignore_case
+        self.case_insensitive = case_insensitive
 
     def order_clause(self):
         order = "ASC" if self.ascending else "DESC"
         field = 'albumartist' if self.album else 'artist'
-        collate = 'COLLATE NOCASE' if self.ignore_case else ''
+        collate = 'COLLATE NOCASE' if self.case_insensitive else ''
         return ('(CASE {0}_sort WHEN NULL THEN {0} '
                 'WHEN "" THEN {0} '
                 'ELSE {0}_sort END) {1} {2}').format(field, collate, order)
@@ -216,7 +216,7 @@ class SmartArtistSort(dbcore.query.Sort):
         else:
             field = lambda i: i.artist_sort or i.artist
 
-        if self.ignore_case:
+        if self.case_insensitive:
             key = lambda x: field(x).lower()
         else:
             key = field

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,11 @@ New features:
   query, items and albums will match *either* side of the comma. For example,
   ``beet ls foo , bar`` will get all the items matching `foo` or matching
   `bar`. See :ref:`combiningqueries`. :bug:`1423`
+* **Sorting is now case insensitive** by default. This means that artists will
+  be sorted lexicographically regardless of case, e.g., *Bar foo Qux*.
+  Previously this would have resulted in *Bar Qux foo*. This behavior can be
+  configured via the :ref:`sort_case_insensitive` configuration option.
+  See :ref:`query-sort`. :bug:`1429`
 
 Little fixes and improvements:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,19 +4,26 @@ Changelog
 1.3.12 (in development)
 -----------------------
 
+This little update makes queries more powerful and removes a performance
+bottleneck.
+
+Packagers should also note a new dependency in this version: the `Jellyfish`_
+Python library makes our text comparisons (a big part of the auto-tagging
+process) go much faster.
+
 New features:
 
-* The autotagger's matching algorithm should be a bit faster. We now
-  use the `Jellyfish`_ library to compute string similarly, which is better
-  optimized than our hand-rolled edit distance implementation. :bug:`1389`
-* :doc:`/plugins/fetchart`: There are new settings to control what constitutes
-  "acceptable" images. The `minwidth` option constrains the minimum image
-  width in pixels and the `enforce_ratio` option requires that images be
-  square. :bug:`1394`
 * Queries can now use **"or" logic**: if you use a comma to separate parts of a
   query, items and albums will match *either* side of the comma. For example,
   ``beet ls foo , bar`` will get all the items matching `foo` or matching
   `bar`. See :ref:`combiningqueries`. :bug:`1423`
+* The autotagger's **matching algorithm is faster**. We now use the
+  `Jellyfish`_ library to compute string similarity, which is better optimized
+  than our hand-rolled edit distance implementation. :bug:`1389`
+* :doc:`/plugins/fetchart`: There are new settings to control what constitutes
+  **"acceptable" images**. The `minwidth` option constrains the minimum image
+  width in pixels and the `enforce_ratio` option requires that images be
+  square. :bug:`1394`
 * **Sorting is now case insensitive** by default. This means that artists will
   be sorted lexicographically regardless of case, e.g., *Bar foo Qux*.
   Previously this would have resulted in *Bar Qux foo*. This behavior can be
@@ -25,8 +32,8 @@ New features:
 
 Little fixes and improvements:
 
-* :doc:`/plugins/fetchart`: Remove hard size limit when fetching from the
-  CoverArtArchive.
+* :doc:`/plugins/fetchart`: Remove a hard size limit when fetching from the
+  Cover Art Archive.
 * The output of the :ref:`fields-cmd` command is now sorted. Thanks to
   :user:`multikatt`. :bug:`1402`
 * :doc:`/plugins/replaygain`: Fix a number of issues with the new

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -204,6 +204,15 @@ sort_album
 Default sort order to use when fetching items from the database. Defaults to
 ``albumartist+ album+``. Explicit sort orders override this default.
 
+.. _sort_case_insensitive:
+
+sort_case_insensitive
+~~~~~~~~~~~~~~~~~~~~~
+Either ``yes`` or ``no``, indicating whether the case should be ignored when
+sorting lexicographic fields. When set to ``no``, lower-case values will be
+placed after upper-case values (e.g., *Bar Qux foo*), while ``yes`` would
+result in the more expected *Bar foo Qux*. Default: ``yes``.
+
 .. _original_date:
 
 original_date

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -223,5 +223,11 @@ The ``artist`` and ``albumartist`` keys are special: they attempt to use their
 corresponding ``artist_sort`` and ``albumartist_sort`` fields for sorting
 transparently (but fall back to the ordinary fields when those are empty).
 
+Lexicographic sorts are case insensitive by default, resulting in the following
+sort order: ``Bar foo Qux``. This behavior can be changed with the
+:ref:`sort_case_insensitive` configuration option. Case sensitive sort will
+result in lower-case values being placed after upper-case values, e.g.,
+``Bar Qux foo``.
+
 You can set the default sorting behavior with the :ref:`sort_item` and
 :ref:`sort_album` configuration options.

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -32,65 +32,65 @@ class DummyDataTestCase(_common.TestCase):
         self.lib = beets.library.Library(':memory:')
 
         albums = [_common.album() for _ in range(3)]
-        albums[0].album = "album A"
+        albums[0].album = "Album A"
         albums[0].genre = "Rock"
         albums[0].year = "2001"
-        albums[0].flex1 = "flex1-1"
-        albums[0].flex2 = "flex2-A"
-        albums[0].albumartist = "foo"
+        albums[0].flex1 = "Flex1-1"
+        albums[0].flex2 = "Flex2-A"
+        albums[0].albumartist = "Foo"
         albums[0].albumartist_sort = None
-        albums[1].album = "album B"
+        albums[1].album = "Album B"
         albums[1].genre = "Rock"
         albums[1].year = "2001"
-        albums[1].flex1 = "flex1-2"
-        albums[1].flex2 = "flex2-A"
-        albums[1].albumartist = "bar"
+        albums[1].flex1 = "Flex1-2"
+        albums[1].flex2 = "Flex2-A"
+        albums[1].albumartist = "Bar"
         albums[1].albumartist_sort = None
-        albums[2].album = "album C"
+        albums[2].album = "Album C"
         albums[2].genre = "Jazz"
         albums[2].year = "2005"
-        albums[2].flex1 = "flex1-1"
-        albums[2].flex2 = "flex2-B"
-        albums[2].albumartist = "baz"
+        albums[2].flex1 = "Flex1-1"
+        albums[2].flex2 = "Flex2-B"
+        albums[2].albumartist = "Baz"
         albums[2].albumartist_sort = None
         for album in albums:
             self.lib.add(album)
 
         items = [_common.item() for _ in range(4)]
-        items[0].title = 'foo bar'
-        items[0].artist = 'one'
-        items[0].album = 'baz'
+        items[0].title = 'Foo bar'
+        items[0].artist = 'One'
+        items[0].album = 'Baz'
         items[0].year = 2001
         items[0].comp = True
-        items[0].flex1 = "flex1-0"
-        items[0].flex2 = "flex2-A"
+        items[0].flex1 = "Flex1-0"
+        items[0].flex2 = "Flex2-A"
         items[0].album_id = albums[0].id
         items[0].artist_sort = None
-        items[1].title = 'baz qux'
-        items[1].artist = 'two'
-        items[1].album = 'baz'
+        items[1].title = 'Baz qux'
+        items[1].artist = 'Two'
+        items[1].album = 'Baz'
         items[1].year = 2002
         items[1].comp = True
-        items[1].flex1 = "flex1-1"
-        items[1].flex2 = "flex2-A"
+        items[1].flex1 = "Flex1-1"
+        items[1].flex2 = "Flex2-A"
         items[1].album_id = albums[0].id
         items[1].artist_sort = None
-        items[2].title = 'beets 4 eva'
-        items[2].artist = 'three'
-        items[2].album = 'foo'
+        items[2].title = 'Beets 4 eva'
+        items[2].artist = 'Three'
+        items[2].album = 'Foo'
         items[2].year = 2003
         items[2].comp = False
-        items[2].flex1 = "flex1-2"
-        items[2].flex2 = "flex1-B"
+        items[2].flex1 = "Flex1-2"
+        items[2].flex2 = "Flex1-B"
         items[2].album_id = albums[1].id
         items[2].artist_sort = None
-        items[3].title = 'beets 4 eva'
-        items[3].artist = 'three'
-        items[3].album = 'foo2'
+        items[3].title = 'Beets 4 eva'
+        items[3].artist = 'Three'
+        items[3].album = 'Foo2'
         items[3].year = 2004
         items[3].comp = False
-        items[3].flex1 = "flex1-2"
-        items[3].flex2 = "flex1-C"
+        items[3].flex1 = "Flex1-2"
+        items[3].flex2 = "Flex1-C"
         items[3].album_id = albums[2].id
         items[3].artist_sort = None
         for item in items:
@@ -132,8 +132,8 @@ class SortFixedFieldTest(DummyDataTestCase):
         results = self.lib.items(q, sort)
         self.assertLessEqual(results[0]['album'], results[1]['album'])
         self.assertLessEqual(results[1]['album'], results[2]['album'])
-        self.assertEqual(results[0]['album'], 'baz')
-        self.assertEqual(results[1]['album'], 'baz')
+        self.assertEqual(results[0]['album'], 'Baz')
+        self.assertEqual(results[1]['album'], 'Baz')
         self.assertLessEqual(results[0]['year'], results[1]['year'])
         # same thing with query string
         q = 'album+ year+'
@@ -148,7 +148,7 @@ class SortFlexFieldTest(DummyDataTestCase):
         sort = dbcore.query.SlowFieldSort("flex1", True)
         results = self.lib.items(q, sort)
         self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
-        self.assertEqual(results[0]['flex1'], 'flex1-0')
+        self.assertEqual(results[0]['flex1'], 'Flex1-0')
         # same thing with query string
         q = 'flex1+'
         results2 = self.lib.items(q)
@@ -162,7 +162,7 @@ class SortFlexFieldTest(DummyDataTestCase):
         self.assertGreaterEqual(results[0]['flex1'], results[1]['flex1'])
         self.assertGreaterEqual(results[1]['flex1'], results[2]['flex1'])
         self.assertGreaterEqual(results[2]['flex1'], results[3]['flex1'])
-        self.assertEqual(results[0]['flex1'], 'flex1-2')
+        self.assertEqual(results[0]['flex1'], 'Flex1-2')
         # same thing with query string
         q = 'flex1-'
         results2 = self.lib.items(q)
@@ -179,8 +179,8 @@ class SortFlexFieldTest(DummyDataTestCase):
         results = self.lib.items(q, sort)
         self.assertGreaterEqual(results[0]['flex2'], results[1]['flex2'])
         self.assertGreaterEqual(results[1]['flex2'], results[2]['flex2'])
-        self.assertEqual(results[0]['flex2'], 'flex2-A')
-        self.assertEqual(results[1]['flex2'], 'flex2-A')
+        self.assertEqual(results[0]['flex2'], 'Flex2-A')
+        self.assertEqual(results[1]['flex2'], 'Flex2-A')
         self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
         # same thing with query string
         q = 'flex2- flex1+'
@@ -269,8 +269,8 @@ class SortAlbumFlexFieldTest(DummyDataTestCase):
         results = self.lib.albums(q, sort)
         self.assertLessEqual(results[0]['flex2'], results[1]['flex2'])
         self.assertLessEqual(results[1]['flex2'], results[2]['flex2'])
-        self.assertEqual(results[0]['flex2'], 'flex2-A')
-        self.assertEqual(results[1]['flex2'], 'flex2-A')
+        self.assertEqual(results[0]['flex2'], 'Flex2-A')
+        self.assertEqual(results[1]['flex2'], 'Flex2-A')
         self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
         # same thing with query string
         q = 'flex2+ flex1+'
@@ -356,6 +356,87 @@ class ConfigSortTest(DummyDataTestCase):
         config['sort_album'] = 'albumartist-'
         results = list(self.lib.albums())
         self.assertGreater(results[0].albumartist, results[1].albumartist)
+
+
+class CaseSensitivityTest(DummyDataTestCase, _common.TestCase):
+    """If case_insensitive is false, lower-case values should be placed
+    after all upper-case values. E.g., `Foo Qux bar`
+    """
+
+    def setUp(self):
+        super(CaseSensitivityTest, self).setUp()
+
+        album = _common.album()
+        album.album = "album"
+        album.genre = "alternative"
+        album.year = "2001"
+        album.flex1 = "flex1"
+        album.flex2 = "flex2-A"
+        album.albumartist = "bar"
+        album.albumartist_sort = None
+        self.lib.add(album)
+
+        item = _common.item()
+        item.title = 'another'
+        item.artist = 'lowercase'
+        item.album = 'album'
+        item.year = 2001
+        item.comp = True
+        item.flex1 = "flex1"
+        item.flex2 = "flex2-A"
+        item.album_id = album.id
+        item.artist_sort = None
+        self.lib.add(item)
+
+        self.new_album = album
+        self.new_item = item
+
+    def tearDown(self):
+        self.new_item.remove(delete=True)
+        self.new_album.remove(delete=True)
+        super(CaseSensitivityTest, self).tearDown()
+
+    def test_smart_artist_case_insensitive(self):
+        config['sort_case_insensitive'] = True
+        q = 'artist+'
+        results = list(self.lib.items(q))
+        self.assertEqual(results[0].artist, 'lowercase')
+        self.assertEqual(results[1].artist, 'One')
+
+    def test_smart_artist_case_sensitive(self):
+        config['sort_case_insensitive'] = False
+        q = 'artist+'
+        results = list(self.lib.items(q))
+        self.assertEqual(results[0].artist, 'One')
+        self.assertEqual(results[-1].artist, 'lowercase')
+
+    def test_fixed_field_case_insensitive(self):
+        config['sort_case_insensitive'] = True
+        q = 'album+'
+        results = list(self.lib.albums(q))
+        self.assertEqual(results[0].album, 'album')
+        self.assertEqual(results[1].album, 'Album A')
+
+    def test_fixed_field_case_sensitive(self):
+        config['sort_case_insensitive'] = False
+        q = 'album+'
+        results = list(self.lib.albums(q))
+        self.assertEqual(results[0].album, 'Album A')
+        self.assertEqual(results[-1].album, 'album')
+
+    def test_flex_field_case_insensitive(self):
+        config['sort_case_insensitive'] = True
+        q = 'flex1+'
+        results = list(self.lib.items(q))
+        self.assertEqual(results[0].flex1, 'flex1')
+        self.assertEqual(results[1].flex1, 'Flex1-0')
+
+    def test_flex_field_case_sensitive(self):
+        config['sort_case_insensitive'] = False
+        q = 'flex1+'
+        results = list(self.lib.items(q))
+        self.assertEqual(results[0].flex1, 'Flex1-0')
+        self.assertEqual(results[-1].flex1, 'flex1')
 
 
 def suite():


### PR DESCRIPTION
The problem surfaced after the "OR"-operator introduction: I noticed that *alt-J* was getting ordered below artists with capital letters, which I found annoying.

With `sort_ignore_case: no` (default):
```
$ ./beet --format-item='$artist' ls alt-j, absynthe minded, arcade fire, warpaint artist+ | uniq
Absynthe Minded
Arcade Fire
Warpaint
alt-J
```

With `sort_ignore_case: yes`:
```
$ ./beet --format-item='$artist' ls alt-j, absynthe minded, arcade fire, warpaint artist+ | uniq
Absynthe Minded
alt-J
Arcade Fire
Warpaint
```

I've left the default behavior as is (respecting case), but it could be argued that ignoring it might be more sensible. Or that it needn't even be configurable, and just always ignore case. Thoughts?
