### PR TITLE
MPDStats Plugin: handle update_rating when item is None / start tests for mpdstats

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -201,8 +201,12 @@ class MPDStats(object):
                             displayable_path(item.path))
 
     def update_rating(self, item, skipped):
-        """Update the rating for a beets item.
+        """Update the rating for a beets item. The `item` can either be a
+        beets `Item` or None. If the item is None, nothing changes.
         """
+        if item is None:
+            return
+
         item.load()
         rating = self.rating(
             int(item.get('play_count', 0)),

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
         'responses',
         'pyxdg',
         'pathlib',
+        'python-mpd',
     ],
 
     # Plugin (optional) dependencies:

--- a/test/test_mpdstats.py
+++ b/test/test_mpdstats.py
@@ -1,0 +1,51 @@
+# This file is part of beets.
+# Copyright 2015
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+
+from mock import Mock
+from test._common import unittest
+from test.helper import TestHelper
+
+from beets.library import Item
+from beetsplug.mpdstats import MPDStats
+
+
+class MPDStatsTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('mpdstats')
+
+    def tearDown(self):
+        self.teardown_beets()
+        self.unload_plugins()
+
+    def test_update_rating(self):
+        item = Item(title='title', path='', id=1)
+        item.add(self.lib)
+
+        log = Mock()
+        mpdstats = MPDStats(self.lib, log)
+
+        self.assertFalse(mpdstats.update_rating(item, True))
+        self.assertFalse(mpdstats.update_rating(None, True))
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == b'__main__':
+    unittest.main(defaultTest='suite')

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     pathlib
     pyxdg
     jellyfish
+    python-mpd
 commands =
     nosetests {posargs}
 


### PR DESCRIPTION
I had a small issue where I would play a song with MPD that wasn't imported by beets. So, when mpdstats tried to update the rating it would throw up an AttributeError that looks like:

```
mpdstats: skipped /media/music/tagged/Z-RO/Relvis Presley/09 One More Time.mp3

Traceback (most recent call last):
  File "/usr/bin/beet", line 9, in <module>
    load_entry_point('beets==1.3.14', 'console_scripts', 'beet')()
  File "/home/cody/src/beets/beets/ui/__init__.py", line 1104, in main
    _raw_main(args)
  File "/home/cody/src/beets/beets/ui/__init__.py", line 1094, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/cody/src/beets/beetsplug/mpdstats.py", line 360, in func
    MPDStats(lib, self._log).run()
  File "/home/cody/src/beets/beetsplug/mpdstats.py", line 306, in run
    handler(status)
  File "/home/cody/src/beets/beetsplug/mpdstats.py", line 253, in on_stop
    self.handle_song_change(self.now_playing)
  File "/home/cody/src/beets/beetsplug/mpdstats.py", line 233, in handle_song_change
    self.update_rating(song['beets_item'], skipped)
  File "/home/cody/src/beets/beetsplug/mpdstats.py", line 206, in update_rating
    item.load()
AttributeError: 'NoneType' object has no attribute 'load'
```

Obviously the better fix would be to import the song with beets ;) - but since MPD can play songs that beets may or may not have, it would be good to sanity check it and not kill the plugin.

Also started some tests for mpdstats which checks this!