### PR TITLE
Replace optparse with Click

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1122,7 +1122,7 @@ def path_option(f):
                         help='print paths for matched items or albums')(f)
 
 
-def format_option(target=None):
+def format_option(flags=('-f', '--format'), target=None):
     def callback(ctx, param, value):
         if not value:
             return
@@ -1146,10 +1146,8 @@ def format_option(target=None):
                 _set_format(library.Album, value)
 
     def decorator(f):
-        return click.option(
-            '-f', '--format', callback=callback,
-            expose_value=False, help='print with custom format'
-        )(f)
+        return click.option(*flags, callback=callback, expose_value=False,
+                            help='print with custom format')(f)
 
     return decorator
 
@@ -1169,6 +1167,8 @@ pass_context = click.make_pass_decorator(Context, ensure=True)
 
 @click.command(cls=BeetsCLI,
                context_settings={'help_option_names': ['-h', '--help']})
+@format_option(flags=('--format-item',), target=library.Item)
+@format_option(flags=('--format-album',), target=library.Album)
 @click.option('-l', '--library', metavar='LIBRARY',
               help='Library database file to use.')
 @click.option('-d', '--directory', metavar='DIRECTORY',

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1403,20 +1403,17 @@ def write_items(lib, query, pretend, force):
             item.try_sync()
 
 
-def write_func(lib, opts, args):
-    write_items(lib, decargs(args), opts.pretend, opts.force)
+@click.command('write', short_help='write tag information to files')
+@click.option('-p', '--pretend', is_flag=True,
+              help='show all changes but do nothing')
+@click.option('-f', '--force', is_flag=True,
+              help='write tags even if the existing tags match the database')
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def write_cmd(ctx, query, pretend, force):
+    write_items(ctx.lib, query, pretend, force)
 
 
-write_cmd = ui.Subcommand('write', help='write tag information to files')
-write_cmd.parser.add_option(
-    '-p', '--pretend', action='store_true',
-    help="show all changes but do nothing"
-)
-write_cmd.parser.add_option(
-    '-f', '--force', action='store_true',
-    help="write tags even if the existing tags match the database"
-)
-write_cmd.func = write_func
 default_commands.append(write_cmd)
 
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -871,102 +871,66 @@ def import_files(lib, paths, query):
     plugins.send('import', lib=lib, paths=paths)
 
 
-def import_func(lib, opts, args):
+# TODO: add 'imp' and 'im' aliases
+@click.command('import', short_help='import new music')
+@click.option('copy', '-c', '--copy', flag_value=True,
+              help='copy tracks into library directory (default)')
+@click.option('copy', '-C', '--nocopy', flag_value=False, default=None,
+              help="don't copy tracks (opposite of -c)")
+@click.option('write', '-w', '--write', flag_value=True,
+              help="write new metadata to files' tags (default)")
+@click.option('write', '-W', '--nowrite', flag_value=False, default=None,
+              help="don't write metadata (opposite of -w)")
+@click.option('autotag', '-a', '--autotag', flag_value=True,
+              help='infer tags for imported files (default)')
+@click.option('autotag', '-A', '--noautotag', flag_value=False, default=None,
+              help="don't infer tags for imported files (opposite of -a)")
+@click.option('resume', '-p', '--resume', flag_value=True,
+              help='resume importing if interrupted')
+@click.option('resume', '-P', '--noresume', flag_value=False, default=None,
+              help='resume importing if interrupted')
+@click.option('-q', '--quiet', is_flag=True, default=None,
+              help='never prompt for input: skip albums instead')
+@click.option('-l', '--log', metavar='LOG', default=None,
+              help='file to log untaggable albums for later review')
+@click.option('-s', '--singletons', is_flag=True, default=None,
+              help='import individual tracks instead of full albums')
+@click.option('-t', '--timid', is_flag=True, default=None,
+              help='always confirm all actions')
+@click.option('-L', '--library', metavar='LIBRARY', default=None,
+              help='retag items matching a query')
+@click.option('incremental', '-i', '--incremental', flag_value=True,
+              help='skip already-import directories')
+@click.option('incremental', '-I', '--noincremental', flag_value=False,
+              default=None, help='do not skip already-imported directories')
+@click.option('--flat', is_flag=True, default=None,
+              help='import an entire tree as a single album')
+@click.option('-g', '--group-albums', is_flag=True, default=None,
+              help='group tracks in a folder into separate albums')
+@click.option('--pretend', is_flag=True, default=None,
+              help='just print the files to import')
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def import_cmd(ctx, query, **opts):
     config['import'].set_args(opts)
 
     # Special case: --copy flag suppresses import_move (which would
     # otherwise take precedence).
-    if opts.copy:
+    if opts['copy']:
         config['import']['move'] = False
 
-    if opts.library:
-        query = decargs(args)
+    if opts['library']:
+        query = decargs(query)
         paths = []
     else:
         query = None
-        paths = args
+        paths = query
         if not paths:
             raise ui.UserError('no path specified')
 
-    import_files(lib, paths, query)
+    import_files(ctx.lib, paths, query)
 
 
-import_cmd = ui.Subcommand(
-    'import', help='import new music', aliases=('imp', 'im')
-)
-import_cmd.parser.add_option(
-    '-c', '--copy', action='store_true', default=None,
-    help="copy tracks into library directory (default)"
-)
-import_cmd.parser.add_option(
-    '-C', '--nocopy', action='store_false', dest='copy',
-    help="don't copy tracks (opposite of -c)"
-)
-import_cmd.parser.add_option(
-    '-w', '--write', action='store_true', default=None,
-    help="write new metadata to files' tags (default)"
-)
-import_cmd.parser.add_option(
-    '-W', '--nowrite', action='store_false', dest='write',
-    help="don't write metadata (opposite of -w)"
-)
-import_cmd.parser.add_option(
-    '-a', '--autotag', action='store_true', dest='autotag',
-    help="infer tags for imported files (default)"
-)
-import_cmd.parser.add_option(
-    '-A', '--noautotag', action='store_false', dest='autotag',
-    help="don't infer tags for imported files (opposite of -a)"
-)
-import_cmd.parser.add_option(
-    '-p', '--resume', action='store_true', default=None,
-    help="resume importing if interrupted"
-)
-import_cmd.parser.add_option(
-    '-P', '--noresume', action='store_false', dest='resume',
-    help="do not try to resume importing"
-)
-import_cmd.parser.add_option(
-    '-q', '--quiet', action='store_true', dest='quiet',
-    help="never prompt for input: skip albums instead"
-)
-import_cmd.parser.add_option(
-    '-l', '--log', dest='log',
-    help='file to log untaggable albums for later review'
-)
-import_cmd.parser.add_option(
-    '-s', '--singletons', action='store_true',
-    help='import individual tracks instead of full albums'
-)
-import_cmd.parser.add_option(
-    '-t', '--timid', dest='timid', action='store_true',
-    help='always confirm all actions'
-)
-import_cmd.parser.add_option(
-    '-L', '--library', dest='library', action='store_true',
-    help='retag items matching a query'
-)
-import_cmd.parser.add_option(
-    '-i', '--incremental', dest='incremental', action='store_true',
-    help='skip already-imported directories'
-)
-import_cmd.parser.add_option(
-    '-I', '--noincremental', dest='incremental', action='store_false',
-    help='do not skip already-imported directories'
-)
-import_cmd.parser.add_option(
-    '--flat', dest='flat', action='store_true',
-    help='import an entire tree as a single album'
-)
-import_cmd.parser.add_option(
-    '-g', '--group-albums', dest='group_albums', action='store_true',
-    help='group tracks in a folder into separate albums'
-)
-import_cmd.parser.add_option(
-    '--pretend', dest='pretend', action='store_true',
-    help='just print the files to import'
-)
-import_cmd.func = import_func
 default_commands.append(import_cmd)
 
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1348,29 +1348,22 @@ def move_items(lib, dest, query, copy, album):
         obj.store()
 
 
-def move_func(lib, opts, args):
-    dest = opts.dest
+# TODO: add 'mv' alias
+@click.command('move', short_help='move or copy items')
+@click.option('-d', '--dest', metavar='DIR', help='destination directory')
+@click.option('-c', '--copy', is_flag=True, help='copy instead of moving')
+@ui.album_option
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def move_cmd(ctx, dest, query, copy, album):
     if dest is not None:
         dest = normpath(dest)
         if not os.path.isdir(dest):
-            raise ui.UserError('no such directory: %s' % dest)
+            raise ui.UserError('no such directory: {}'.format(dest))
 
-    move_items(lib, dest, decargs(args), opts.copy, opts.album)
+    move_items(ctx.lib, dest, query, copy, album)
 
 
-move_cmd = ui.Subcommand(
-    'move', help='move or copy items', aliases=('mv',)
-)
-move_cmd.parser.add_option(
-    '-d', '--dest', metavar='DIR', dest='dest',
-    help='destination directory'
-)
-move_cmd.parser.add_option(
-    '-c', '--copy', default=False, action='store_true',
-    help='copy instead of moving'
-)
-move_cmd.parser.add_album_option()
-move_cmd.func = move_func
 default_commands.append(move_cmd)
 
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -984,13 +984,15 @@ def list_items(lib, query, album, fmt=''):
             ui.print_(format(item, fmt))
 
 
-def list_func(lib, opts, args):
-    list_items(lib, decargs(args), opts.album)
+# TODO: add 'ls' alias
+@click.command('list', short_help='query the library')
+@click.argument('query', nargs=-1)
+@ui.all_common_options
+@ui.pass_context
+def list_cmd(ctx, query, album, path):
+    list_items(ctx.lib, query, album)
 
 
-list_cmd = ui.Subcommand('list', help='query the library', aliases=('ls',))
-list_cmd.parser.add_all_common_options()
-list_cmd.func = list_func
 default_commands.append(list_cmd)
 
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1085,24 +1085,20 @@ def update_items(lib, query, album, move, pretend):
                 album.move()
 
 
-def update_func(lib, opts, args):
-    update_items(lib, decargs(args), opts.album, opts.move, opts.pretend)
+# TODO: add 'up' and 'upd' aliases
+@click.command('update', short_help='update the library')
+@ui.album_option
+@ui.format_option()
+@click.option('move', '-M', '--nomove', is_flag=True, default=True,
+              help="don't move files in library")
+@click.option('-p', '--pretend', is_flag=True,
+              help='show all changes but do nothing')
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def update_cmd(ctx, query, album, move, pretend):
+    update_items(ctx.lib, query, album, move, pretend)
 
 
-update_cmd = ui.Subcommand(
-    'update', help='update the library', aliases=('upd', 'up',)
-)
-update_cmd.parser.add_album_option()
-update_cmd.parser.add_format_option()
-update_cmd.parser.add_option(
-    '-M', '--nomove', action='store_false', default=True, dest='move',
-    help="don't move files in library"
-)
-update_cmd.parser.add_option(
-    '-p', '--pretend', action='store_true',
-    help="show all changes but do nothing"
-)
-update_cmd.func = update_func
 default_commands.append(update_cmd)
 
 
@@ -1139,19 +1135,17 @@ def remove_items(lib, query, album, delete):
             obj.remove(delete)
 
 
-def remove_func(lib, opts, args):
-    remove_items(lib, decargs(args), opts.album, opts.delete)
+# TODO: add 'rm' alias
+@click.command('remove', short_help='remove matching items from the library')
+@click.option('-d', '--delete', is_flag=True,
+              help='also remove files from disk')
+@ui.album_option
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def remove_cmd(ctx, query, album, delete):
+    remove_items(ctx.lib, query, album, delete)
 
 
-remove_cmd = ui.Subcommand(
-    'remove', help='remove matching items from the library', aliases=('rm',)
-)
-remove_cmd.parser.add_option(
-    "-d", "--delete", action="store_true",
-    help="also remove files from disk"
-)
-remove_cmd.parser.add_album_option()
-remove_cmd.func = remove_func
 default_commands.append(remove_cmd)
 
 
@@ -1309,38 +1303,28 @@ def modify_parse_args(args):
     return query, mods, dels
 
 
-def modify_func(lib, opts, args):
-    query, mods, dels = modify_parse_args(decargs(args))
+# TODO: add 'mod' alias
+@click.command('modify', short_help='change metadata fields')
+@click.option('move', '-M', '--nomove', is_flag=True, default=True,
+              help="don't move files in library")
+@click.option('write', '-w', '--write', flag_value=True,
+              help="write new metadata to files' tags (default)")
+@click.option('write', '-W', '--nowrite', flag_value=False, default=None,
+              help="don't write metadata (opposite of -w)")
+@ui.album_option
+@ui.format_option(target='item')
+@click.option('-y', '--yes', is_flag=True, help='skip_confirmation')
+@click.argument('query', nargs=-1)
+@ui.pass_context
+def modify_cmd(ctx, query, write, move, album, yes):
+    query, mods, dels = modify_parse_args(query)
     if not mods and not dels:
         raise ui.UserError('no modifications specified')
-    write = opts.write if opts.write is not None else \
+    write = write if write is not None else \
         config['import']['write'].get(bool)
-    modify_items(lib, mods, dels, query, write, opts.move, opts.album,
-                 not opts.yes)
+    modify_items(ctx.lib, mods, dels, query, write, move, album, not yes)
 
 
-modify_cmd = ui.Subcommand(
-    'modify', help='change metadata fields', aliases=('mod',)
-)
-modify_cmd.parser.add_option(
-    '-M', '--nomove', action='store_false', default=True, dest='move',
-    help="don't move files in library"
-)
-modify_cmd.parser.add_option(
-    '-w', '--write', action='store_true', default=None,
-    help="write new metadata to files' tags (default)"
-)
-modify_cmd.parser.add_option(
-    '-W', '--nowrite', action='store_false', dest='write',
-    help="don't write metadata (opposite of -w)"
-)
-modify_cmd.parser.add_album_option()
-modify_cmd.parser.add_format_option(target='item')
-modify_cmd.parser.add_option(
-    '-y', '--yes', action='store_true',
-    help='skip confirmation'
-)
-modify_cmd.func = modify_func
 default_commands.append(modify_cmd)
 
 

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -238,7 +238,11 @@ class ConfigView(object):
         like argparse or optparse, onto this view's value.
         """
         args = {}
-        for key, value in namespace.__dict__.items():
+        if isinstance(namespace, dict):
+            items = namespace.items()
+        else:
+            items = namespace.__dict__.items()
+        for key, value in items:
             if value is not None:  # Avoid unset options.
                 args[key] = value
         self.set(args)

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         'musicbrainzngs>=0.4',
         'pyyaml',
         'jellyfish',
+        'click',
     ] + (['colorama'] if (sys.platform == 'win32') else []) +
         (['ordereddict'] if sys.version_info < (2, 7, 0) else []),
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -410,7 +410,11 @@ class TestHelper(object):
             lib = self.lib
         else:
             lib = Library(':memory:')
-        beets.ui._raw_main(list(args), lib)
+        ctx = beets.ui.Context(lib=lib)
+        try:
+            beets.ui._raw_main(args=args, obj=ctx)
+        except SystemExit:
+            pass
 
     def run_with_output(self, *args):
         with capture_stdout() as out:


### PR DESCRIPTION
(For reference see #1442)

- [x] Custom `MultiCommand` subclass to dynamically find commands
- [x] Context object to pass `lib` object (pass config in the future)
- [x] Change `confit` to accept dict-based options
- [x] commands: `help`, `fields`, `version`, `stats`, `config`
- [x] Replacement decorators for `add_(album|format|path)_option`
- [x] commands: `list`, `remove`, `modify`, `update`, `write`, `move`
- [x] last command: `import`
- [x] Plugins
- [ ] Tests (use `click.testing.CliRunner`?)
- [ ] Aliases
- [ ] Bash completion
- [ ] Remove unused code
- [ ] ...?