### PR TITLE
MetaSync: more OO structure +  iTunes support 

### DIFF
--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -57,8 +57,8 @@ def load_meta_sources():
         module = import_module(METASYNC_MODULE + '.' + module_name)
         classes = inspect.getmembers(module, is_meta_source_implementation)
 
-        for cls_name, cls in classes:
-            meta_sources[cls_name.lower()] = cls
+        for cls_name, _cls in classes:
+            meta_sources[cls_name.lower()] = _cls
 
     return meta_sources
 

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -34,7 +34,13 @@ class MetaSyncPlugin(BeetsPlugin):
         'amarok_uid':         types.STRING,
         'amarok_playcount':   types.INTEGER,
         'amarok_firstplayed': DateType(),
-        'amarok_lastplayed':  DateType()
+        'amarok_lastplayed':  DateType(),
+
+        'itunes_rating':      types.INTEGER,  # 0..100 scale
+        'itunes_playcount':   types.INTEGER,
+        'itunes_skipcount':   types.INTEGER,
+        'itunes_lastplayed':  DateType(),
+        'itunes_lastskipped': DateType(),
     }
 
     def __init__(self):
@@ -74,7 +80,7 @@ class MetaSyncPlugin(BeetsPlugin):
 
             for entry in classes:
                 if entry[0].lower() == player:
-                    sources[player] = entry[1]()
+                    sources[player] = entry[1](self.config)
                 else:
                     continue
 

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -31,7 +31,7 @@ class Amarok(object):
                     </filters> \
                 </query>'
 
-    def __init__(self):
+    def __init__(self, config=None):
         self.collection = \
             dbus.SessionBus().get_object('org.kde.amarok', '/Collection')
 

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -18,14 +18,33 @@
 from os.path import basename
 from datetime import datetime
 from time import mktime
-from beets.util import displayable_path
 from xml.sax.saxutils import escape
+
+from beets.util import displayable_path
+from beets.dbcore import types
+from beets.library import DateType
 from beetsplug.metasync import MetaSource
 
-import dbus
+
+def import_dbus():
+    try:
+        return __import__('dbus')
+    except ImportError:
+        return None
+
+dbus = import_dbus()
 
 
 class Amarok(MetaSource):
+
+    item_types = {
+        'amarok_rating':      types.INTEGER,
+        'amarok_score':       types.FLOAT,
+        'amarok_uid':         types.STRING,
+        'amarok_playcount':   types.INTEGER,
+        'amarok_firstplayed': DateType(),
+        'amarok_lastplayed':  DateType(),
+    }
 
     queryXML = u'<query version="1.0"> \
                     <filters> \
@@ -35,6 +54,9 @@ class Amarok(MetaSource):
 
     def __init__(self, config, log):
         super(Amarok, self).__init__(config, log)
+
+        if not dbus:
+            raise ImportError('failed to import dbus')
 
         self.collection = \
             dbus.SessionBus().get_object('org.kde.amarok', '/Collection')

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -61,7 +61,7 @@ class Amarok(MetaSource):
         self.collection = \
             dbus.SessionBus().get_object('org.kde.amarok', '/Collection')
 
-    def sync_data(self, item):
+    def sync_from_source(self, item):
         path = displayable_path(item.path)
 
         # amarok unfortunately doesn't allow searching for the full path, only

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -20,10 +20,12 @@ from datetime import datetime
 from time import mktime
 from beets.util import displayable_path
 from xml.sax.saxutils import escape
+from beetsplug.metasync import MetaSource
+
 import dbus
 
 
-class Amarok(object):
+class Amarok(MetaSource):
 
     queryXML = u'<query version="1.0"> \
                     <filters> \
@@ -31,11 +33,13 @@ class Amarok(object):
                     </filters> \
                 </query>'
 
-    def __init__(self, config=None):
+    def __init__(self, config, log):
+        super(Amarok, self).__init__(config, log)
+
         self.collection = \
             dbus.SessionBus().get_object('org.kde.amarok', '/Collection')
 
-    def get_data(self, item):
+    def sync_data(self, item):
         path = displayable_path(item.path)
 
         # amarok unfortunately doesn't allow searching for the full path, only

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -1,0 +1,80 @@
+# This file is part of beets.
+# Copyright 2015, Tom Jaspers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Synchronize information from iTunes's library
+"""
+from contextlib import contextmanager
+import os
+import shutil
+import tempfile
+from time import mktime
+
+import plistlib
+from beets import util
+from beets.util.confit import ConfigValueError
+
+
+@contextmanager
+def create_temporary_copy(path):
+    temp_dir = tempfile.gettempdir()
+    temp_path = os.path.join(temp_dir, 'temp_itunes_lib')
+    shutil.copyfile(path, temp_path)
+    try:
+        yield temp_path
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+class ITunes(object):
+
+    def __init__(self, config=None):
+        # Load the iTunes library, which has to be the .xml one
+        library_path = util.normpath(config['itunes']['library'].get(str))
+
+        try:
+            with create_temporary_copy(library_path) as library_copy:
+                raw_library = plistlib.readPlist(library_copy)
+        except IOError as e:
+            raise ConfigValueError("invalid iTunes library: " + e.strerror)
+        except:
+            # TODO: Tell user to make sure it is the .xml one?
+            raise ConfigValueError("invalid iTunes library")
+
+        # Convert the library in to something we can query more easily
+        self.collection = {
+            (track['Name'], track['Album'], track['Album Artist']): track
+            for track in raw_library['Tracks'].values()}
+
+    def get_data(self, item):
+        key = (item.title, item.album, item.albumartist)
+        result = self.collection.get(key)
+
+        # TODO: Need to investigate behavior for items without title, album, or
+        # albumartist before allowing them to be queried
+        if not all(key) or not result:
+            # TODO: Need to log something here later
+            # print "No iTunes match found for {0}".format(item)
+            return
+
+        item.itunes_rating = result.get('Rating')
+        item.itunes_playcount = result.get('Play Count')
+        item.itunes_skipcount = result.get('Skip Count')
+
+        if result.get('Play Date UTC'):
+            item.itunes_lastplayed = mktime(
+                result.get('Play Date UTC').timetuple())
+
+        if result.get('Skip Date'):
+            item.itunes_lastskipped = mktime(
+                result.get('Skip Date').timetuple())

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -30,7 +30,7 @@ from beetsplug.metasync import MetaSource
 
 @contextmanager
 def create_temporary_copy(path):
-    temp_dir = tempfile.gettempdir()
+    temp_dir = tempfile.mkdtemp()
     temp_path = os.path.join(temp_dir, 'temp_itunes_lib')
     shutil.copyfile(path, temp_path)
     try:
@@ -76,7 +76,7 @@ class Itunes(MetaSource):
             (track['Name'], track['Album'], track['Album Artist']): track
             for track in raw_library['Tracks'].values()}
 
-    def sync_data(self, item):
+    def sync_from_source(self, item):
         key = (item.title, item.album, item.albumartist)
         result = self.collection.get(key)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 New features:
 
 * The :doc:`/plugins/metasync` plugin now lets you get metadata from iTunes.
-  This plugin is still in an experimental phase.
+  This plugin is still in an experimental phase. :bug:`1450`
 
 
 Fixes:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 1.3.14 (in development)
 -----------------------
 
+New features:
+
+* The :doc:`/plugins/metasync` plugin now lets you get metadata from iTunes.
+  This plugin is still in an experimental phase.
+
+
 Fixes:
 
 * :doc:`/plugins/mpdstats`: Avoid a crash when the music played is not in the

--- a/docs/plugins/metasync.rst
+++ b/docs/plugins/metasync.rst
@@ -42,7 +42,7 @@ itunes
 
 The path to your iTunes library **xml** file has to be configured, e.g.::
 
-    metaysnc:
+    metasync:
         source: itunes
         itunes:
             library: ~/Music/iTunes Library.xml

--- a/docs/plugins/metasync.rst
+++ b/docs/plugins/metasync.rst
@@ -4,11 +4,13 @@ MetaSync Plugin
 This plugin provides the ``metasync`` command, which lets you fetch certain
 metadata from other sources: for example, your favorite audio player.
 
-Currently, the plugin supports synchronizing with the `Amarok`_ music player.
+Currently, the plugin supports synchronizing with the `Amarok`_ music player,
+and with `iTunes`_.
 It can fetch the rating, score, first-played date, last-played date, play
 count, and track uid from Amarok.
 
 .. _Amarok: https://amarok.kde.org/
+.. _iTunes: https://www.apple.com/itunes/
 
 
 Installation
@@ -29,10 +31,23 @@ Configuration
 To configure the plugin, make a ``metasync:`` section in your configuration
 file. The available options are:
 
-- **source**: A list of sources to fetch metadata from. Set this to "amarok"
-  to enable synchronization with that player.
+- **source**: A list of sources to fetch metadata from. Set this to "amarok" or
+  "itunes" to enable synchronization with that player.
   Default: empty
 
+The follow subsections describe additional configure required for some players.
+
+itunes
+''''''
+
+The path to your iTunes library **xml** file has to be configured, e.g.::
+
+    metaysnc:
+        source: itunes
+        itunes:
+            library: ~/Music/iTunes Library.xml
+
+Please note the indentation.
 
 Usage
 -----

--- a/docs/plugins/metasync.rst
+++ b/docs/plugins/metasync.rst
@@ -31,8 +31,8 @@ Configuration
 To configure the plugin, make a ``metasync:`` section in your configuration
 file. The available options are:
 
-- **source**: A list of sources to fetch metadata from. Set this to "amarok" or
-  "itunes" to enable synchronization with that player.
+- **source**: A list of comma-separated sources to fetch metadata from.
+  Set this to "amarok" or "itunes" to enable synchronization with that player.
   Default: empty
 
 The follow subsections describe additional configure required for some players.
@@ -59,5 +59,5 @@ The command has a few command-line options:
 
 * To preview the changes that would be made without applying them, use the
   ``-p`` (``--pretend``) flag.
-* To specify a temporary source to fetch metadata from, use the ``-s``
-  (``--source``) flag.
+* To specify temporary sources to fetch metadata from, use the ``-s``
+  (``--source``) flag with a comma-separated list of a sources.

--- a/test/rsrc/itunes_library.xml
+++ b/test/rsrc/itunes_library.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Date</key><date>2015-05-08T14:36:28Z</date>
+	<key>Application Version</key><string>12.1.2.27</string>
+	<key>Features</key><integer>5</integer>
+	<key>Show Content Ratings</key><true/>
+	<key>Music Folder</key><string>file:///beetstests/Music/iTunes/iTunes%20Media/</string>
+	<key>Library Persistent ID</key><string>1ABA8417E4946A32</string>
+	<key>Tracks</key>
+	<dict>
+		<key>634</key>
+		<dict>
+			<key>Track ID</key><integer>634</integer>
+			<key>Name</key><string>Tessellate</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Genre</key><string>Alternative</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>5525212</integer>
+			<key>Total Time</key><integer>182674</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>3</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-02-02T15:23:08Z</date>
+			<key>Date Added</key><date>2014-04-24T09:28:38Z</date>
+			<key>Bit Rate</key><integer>238</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>0</integer>
+			<key>Play Date</key><integer>3513593824</integer>
+			<key>Skip Count</key><integer>3</integer>
+			<key>Skip Date</key><date>2015-02-05T15:41:04Z</date>
+			<key>Rating</key><integer>80</integer>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>20E89D1580C31363</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file:///beetstests/Music/Music/Alt-J/An%20Awesome%20Wave/03%20Tessellate.mp3</string>
+			<key>File Folder Count</key><integer>4</integer>
+			<key>Library Folder Count</key><integer>2</integer>
+		</dict>
+		<key>636</key>
+		<dict>
+			<key>Track ID</key><integer>636</integer>
+			<key>Name</key><string>Breezeblocks</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Genre</key><string>Alternative</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>6827195</integer>
+			<key>Total Time</key><integer>227082</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>4</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-02-02T15:23:08Z</date>
+			<key>Date Added</key><date>2014-04-24T09:28:38Z</date>
+			<key>Bit Rate</key><integer>237</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>31</integer>
+			<key>Play Date</key><integer>3513594051</integer>
+			<key>Play Date UTC</key><date>2015-05-04T12:20:51Z</date>
+			<key>Skip Count</key><integer>0</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>D7017B127B983D38</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file:///beetstests/Music/Music/Alt-J/An%20Awesome%20Wave/04%20Breezeblocks.mp3</string>
+			<key>File Folder Count</key><integer>4</integer>
+			<key>Library Folder Count</key><integer>2</integer>
+		</dict>
+	</dict>
+	<key>Playlists</key>
+	<array>
+		<dict>
+			<key>Name</key><string>Library</string>
+			<key>Master</key><true/>
+			<key>Playlist ID</key><integer>11480</integer>
+			<key>Playlist Persistent ID</key><string>CD6FF684E7A6A166</string>
+			<key>Visible</key><false/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>634</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>636</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Music</string>
+			<key>Playlist ID</key><integer>16906</integer>
+			<key>Playlist Persistent ID</key><string>4FB2E64E0971DD45</string>
+			<key>Distinguished Kind</key><integer>4</integer>
+			<key>Music</key><true/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>634</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>636</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Movies</string>
+			<key>Playlist ID</key><integer>22338</integer>
+			<key>Playlist Persistent ID</key><string>ED848683ABD912C5</string>
+			<key>Distinguished Kind</key><integer>2</integer>
+			<key>Movies</key><true/>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>TV Shows</string>
+			<key>Playlist ID</key><integer>22344</integer>
+			<key>Playlist Persistent ID</key><string>030882163A22E881</string>
+			<key>Distinguished Kind</key><integer>3</integer>
+			<key>TV Shows</key><true/>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>Podcasts</string>
+			<key>Playlist ID</key><integer>22347</integer>
+			<key>Playlist Persistent ID</key><string>8A8C2A6F094235CF</string>
+			<key>Distinguished Kind</key><integer>10</integer>
+			<key>Podcasts</key><true/>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>iTunes U</string>
+			<key>Playlist ID</key><integer>22354</integer>
+			<key>Playlist Persistent ID</key><string>571BAA51CE17C191</string>
+			<key>Distinguished Kind</key><integer>31</integer>
+			<key>iTunesU</key><true/>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>Audiobooks</string>
+			<key>Playlist ID</key><integer>22357</integer>
+			<key>Playlist Persistent ID</key><string>2D2BE73BF9612562</string>
+			<key>Distinguished Kind</key><integer>5</integer>
+			<key>Audiobooks</key><true/>
+			<key>All Items</key><true/>
+		</dict>
+		<dict>
+			<key>Name</key><string>Genius</string>
+			<key>Playlist ID</key><integer>22372</integer>
+			<key>Playlist Persistent ID</key><string>F35301460DED0A7A</string>
+			<key>Distinguished Kind</key><integer>26</integer>
+			<key>All Items</key><true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/test/rsrc/itunes_library_unix.xml
+++ b/test/rsrc/itunes_library_unix.xml
@@ -8,7 +8,7 @@
 	<key>Application Version</key><string>12.1.2.27</string>
 	<key>Features</key><integer>5</integer>
 	<key>Show Content Ratings</key><true/>
-	<key>Music Folder</key><string>file:///beetstests/Music/iTunes/iTunes%20Media/</string>
+	<key>Music Folder</key><string>file:////Music/</string>
 	<key>Library Persistent ID</key><string>1ABA8417E4946A32</string>
 	<key>Tracks</key>
 	<dict>
@@ -44,7 +44,7 @@
 			<key>Sort Artist</key><string>alt-J</string>
 			<key>Persistent ID</key><string>20E89D1580C31363</string>
 			<key>Track Type</key><string>File</string>
-			<key>Location</key><string>file:///beetstests/Music/Music/Alt-J/An%20Awesome%20Wave/03%20Tessellate.mp3</string>
+			<key>Location</key><string>file:///Music/Alt-J/An%20Awesome%20Wave/03%20Tessellate.mp3</string>
 			<key>File Folder Count</key><integer>4</integer>
 			<key>Library Folder Count</key><integer>2</integer>
 		</dict>
@@ -80,7 +80,42 @@
 			<key>Sort Artist</key><string>alt-J</string>
 			<key>Persistent ID</key><string>D7017B127B983D38</string>
 			<key>Track Type</key><string>File</string>
-			<key>Location</key><string>file:///beetstests/Music/Music/Alt-J/An%20Awesome%20Wave/04%20Breezeblocks.mp3</string>
+			<key>Location</key><string>file://localhost/Music/Alt-J/An%20Awesome%20Wave/04%20Breezeblocks.mp3</string>
+			<key>File Folder Count</key><integer>4</integer>
+			<key>Library Folder Count</key><integer>2</integer>
+		</dict>
+        <key>638</key>
+		<dict>
+			<key>Track ID</key><integer>638</integer>
+			<key>Name</key><string>❦ (Ripe &#38; Ruin)</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>2173293</integer>
+			<key>Total Time</key><integer>72097</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>2</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-05-09T17:04:53Z</date>
+			<key>Date Added</key><date>2015-02-02T15:28:39Z</date>
+			<key>Bit Rate</key><integer>233</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>8</integer>
+			<key>Play Date</key><integer>3514109973</integer>
+			<key>Play Date UTC</key><date>2015-05-10T11:39:33Z</date>
+			<key>Skip Count</key><integer>1</integer>
+			<key>Skip Date</key><date>2015-02-02T15:29:10Z</date>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>183699FA0554D0E6</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file:///Music/Alt-J/An%20Awesome%20Wave/02%20%E2%9D%A6%20(Ripe%20&#38;%20Ruin).mp3</string>
 			<key>File Folder Count</key><integer>4</integer>
 			<key>Library Folder Count</key><integer>2</integer>
 		</dict>
@@ -102,6 +137,9 @@
 				<dict>
 					<key>Track ID</key><integer>636</integer>
 				</dict>
+                <dict>
+					<key>Track ID</key><integer>638</integer>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -119,54 +157,10 @@
 				<dict>
 					<key>Track ID</key><integer>636</integer>
 				</dict>
+                <dict>
+					<key>Track ID</key><integer>638</integer>
+				</dict>
 			</array>
-		</dict>
-		<dict>
-			<key>Name</key><string>Movies</string>
-			<key>Playlist ID</key><integer>22338</integer>
-			<key>Playlist Persistent ID</key><string>ED848683ABD912C5</string>
-			<key>Distinguished Kind</key><integer>2</integer>
-			<key>Movies</key><true/>
-			<key>All Items</key><true/>
-		</dict>
-		<dict>
-			<key>Name</key><string>TV Shows</string>
-			<key>Playlist ID</key><integer>22344</integer>
-			<key>Playlist Persistent ID</key><string>030882163A22E881</string>
-			<key>Distinguished Kind</key><integer>3</integer>
-			<key>TV Shows</key><true/>
-			<key>All Items</key><true/>
-		</dict>
-		<dict>
-			<key>Name</key><string>Podcasts</string>
-			<key>Playlist ID</key><integer>22347</integer>
-			<key>Playlist Persistent ID</key><string>8A8C2A6F094235CF</string>
-			<key>Distinguished Kind</key><integer>10</integer>
-			<key>Podcasts</key><true/>
-			<key>All Items</key><true/>
-		</dict>
-		<dict>
-			<key>Name</key><string>iTunes U</string>
-			<key>Playlist ID</key><integer>22354</integer>
-			<key>Playlist Persistent ID</key><string>571BAA51CE17C191</string>
-			<key>Distinguished Kind</key><integer>31</integer>
-			<key>iTunesU</key><true/>
-			<key>All Items</key><true/>
-		</dict>
-		<dict>
-			<key>Name</key><string>Audiobooks</string>
-			<key>Playlist ID</key><integer>22357</integer>
-			<key>Playlist Persistent ID</key><string>2D2BE73BF9612562</string>
-			<key>Distinguished Kind</key><integer>5</integer>
-			<key>Audiobooks</key><true/>
-			<key>All Items</key><true/>
-		</dict>
-		<dict>
-			<key>Name</key><string>Genius</string>
-			<key>Playlist ID</key><integer>22372</integer>
-			<key>Playlist Persistent ID</key><string>F35301460DED0A7A</string>
-			<key>Distinguished Kind</key><integer>26</integer>
-			<key>All Items</key><true/>
 		</dict>
 	</array>
 </dict>

--- a/test/rsrc/itunes_library_windows.xml
+++ b/test/rsrc/itunes_library_windows.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Date</key><date>2015-05-11T15:27:14Z</date>
+	<key>Application Version</key><string>12.1.2.27</string>
+	<key>Features</key><integer>5</integer>
+	<key>Show Content Ratings</key><true/>
+	<key>Music Folder</key><string>file://localhost/C:/Documents%20and%20Settings/Owner/My%20Documents/My%20Music/iTunes/iTunes%20Media/</string>
+	<key>Library Persistent ID</key><string>B4C9F3EE26EFAF78</string>
+	<key>Tracks</key>
+	<dict>
+		<key>180</key>
+		<dict>
+			<key>Track ID</key><integer>180</integer>
+            <key>Name</key><string>Tessellate</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Genre</key><string>Alternative</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>5525212</integer>
+			<key>Total Time</key><integer>182674</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>3</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-02-02T15:23:08Z</date>
+			<key>Date Added</key><date>2014-04-24T09:28:38Z</date>
+			<key>Bit Rate</key><integer>238</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>0</integer>
+			<key>Play Date</key><integer>3513593824</integer>
+			<key>Skip Count</key><integer>3</integer>
+			<key>Skip Date</key><date>2015-02-05T15:41:04Z</date>
+			<key>Rating</key><integer>80</integer>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>20E89D1580C31363</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file://localhost/G:/Music/Alt-J/An%20Awesome%20Wave/03%20Tessellate.mp3</string>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+		</dict>
+		<key>183</key>
+		<dict>
+			<key>Track ID</key><integer>183</integer>
+			<key>Name</key><string>Breezeblocks</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Genre</key><string>Alternative</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>6827195</integer>
+			<key>Total Time</key><integer>227082</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>4</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-02-02T15:23:08Z</date>
+			<key>Date Added</key><date>2014-04-24T09:28:38Z</date>
+			<key>Bit Rate</key><integer>237</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>31</integer>
+			<key>Play Date</key><integer>3513594051</integer>
+			<key>Play Date UTC</key><date>2015-05-04T12:20:51Z</date>
+			<key>Skip Count</key><integer>0</integer>
+			<key>Rating</key><integer>100</integer>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>D7017B127B983D38</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file://localhost/G:/Music/Alt-J/An%20Awesome%20Wave/04%20Breezeblocks.mp3</string>
+			<key>File Folder Count</key><integer>-1</integer>
+			<key>Library Folder Count</key><integer>-1</integer>
+		</dict>
+        <key>638</key>
+		<dict>
+			<key>Track ID</key><integer>638</integer>
+			<key>Name</key><string>❦ (Ripe &#38; Ruin)</string>
+			<key>Artist</key><string>alt-J</string>
+			<key>Album Artist</key><string>alt-J</string>
+			<key>Album</key><string>An Awesome Wave</string>
+			<key>Kind</key><string>MPEG audio file</string>
+			<key>Size</key><integer>2173293</integer>
+			<key>Total Time</key><integer>72097</integer>
+			<key>Disc Number</key><integer>1</integer>
+			<key>Disc Count</key><integer>1</integer>
+			<key>Track Number</key><integer>2</integer>
+			<key>Track Count</key><integer>13</integer>
+			<key>Year</key><integer>2012</integer>
+			<key>Date Modified</key><date>2015-05-09T17:04:53Z</date>
+			<key>Date Added</key><date>2015-02-02T15:28:39Z</date>
+			<key>Bit Rate</key><integer>233</integer>
+			<key>Sample Rate</key><integer>44100</integer>
+			<key>Play Count</key><integer>8</integer>
+			<key>Play Date</key><integer>3514109973</integer>
+			<key>Play Date UTC</key><date>2015-05-10T11:39:33Z</date>
+			<key>Skip Count</key><integer>1</integer>
+			<key>Skip Date</key><date>2015-02-02T15:29:10Z</date>
+			<key>Album Rating</key><integer>80</integer>
+			<key>Album Rating Computed</key><true/>
+			<key>Artwork Count</key><integer>1</integer>
+			<key>Sort Album</key><string>Awesome Wave</string>
+			<key>Sort Artist</key><string>alt-J</string>
+			<key>Persistent ID</key><string>183699FA0554D0E6</string>
+			<key>Track Type</key><string>File</string>
+			<key>Location</key><string>file://localhost/G:/Experiments/Alt-J/An%20Awesome%20Wave/02%20%E2%9D%A6%20(Ripe%20&#38;%20Ruin).mp3</string>
+			<key>File Folder Count</key><integer>4</integer>
+			<key>Library Folder Count</key><integer>2</integer>
+		</dict>
+	</dict>
+	<key>Playlists</key>
+	<array>
+		<dict>
+			<key>Name</key><string>Bibliotheek</string>
+			<key>Master</key><true/>
+			<key>Playlist ID</key><integer>72</integer>
+			<key>Playlist Persistent ID</key><string>728AA5B1D00ED23B</string>
+			<key>Visible</key><false/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>180</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>183</integer>
+				</dict>
+                <dict>
+					<key>Track ID</key><integer>638</integer>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>Name</key><string>Muziek</string>
+			<key>Playlist ID</key><integer>103</integer>
+			<key>Playlist Persistent ID</key><string>8120A002B0486AD7</string>
+			<key>Distinguished Kind</key><integer>4</integer>
+			<key>Music</key><true/>
+			<key>All Items</key><true/>
+			<key>Playlist Items</key>
+			<array>
+				<dict>
+					<key>Track ID</key><integer>180</integer>
+				</dict>
+				<dict>
+					<key>Track ID</key><integer>183</integer>
+				</dict>
+                <dict>
+					<key>Track ID</key><integer>638</integer>
+				</dict>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -12,11 +12,17 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 import os
+import time
+from datetime import datetime
 from beets.library import Item
 
 from test import _common
 from test._common import unittest
 from test.helper import TestHelper
+
+
+def _parsetime(s):
+    return time.mktime(datetime.strptime(s, '%Y-%m-%d %H:%M:%S').timetuple())
 
 
 class MetaSyncTest(_common.TestCase, TestHelper):
@@ -75,12 +81,14 @@ class MetaSyncTest(_common.TestCase, TestHelper):
         self.assertEqual(self.lib.items()[0].itunes_playcount, 0)
         self.assertEqual(self.lib.items()[0].itunes_skipcount, 3)
         self.assertFalse(hasattr(self.lib.items()[0], 'itunes_lastplayed'))
-        self.assertEqual(self.lib.items()[0].itunes_lastskipped, 1423147264.0)
+        self.assertEqual(self.lib.items()[0].itunes_lastskipped,
+                         _parsetime('2015-02-05 15:41:04'))
 
         self.assertEqual(self.lib.items()[1].itunes_rating, 100)
         self.assertEqual(self.lib.items()[1].itunes_playcount, 31)
         self.assertEqual(self.lib.items()[1].itunes_skipcount, 0)
-        self.assertEqual(self.lib.items()[1].itunes_lastplayed, 1430734851.0)
+        self.assertEqual(self.lib.items()[1].itunes_lastplayed,
+                         _parsetime('2015-05-04 12:20:51'))
         self.assertFalse(hasattr(self.lib.items()[1], 'itunes_lastskipped'))
 
 

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -1,0 +1,91 @@
+# This file is part of beets.
+# Copyright 2015, Tom Jaspers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+import os
+from beets.library import Item
+
+from test import _common
+from test._common import unittest
+from test.helper import TestHelper
+
+
+class MetaSyncTest(_common.TestCase, TestHelper):
+    itunes_library = os.path.join(_common.RSRC, 'itunes_library.xml')
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('metasync')
+
+        self.config['metasync']['source'] = 'itunes'
+        self.config['metasync']['itunes']['library'] = self.itunes_library
+
+        self._set_up_data()
+
+    def _set_up_data(self):
+        items = [_common.item() for _ in range(2)]
+        items[0].title = 'Tessellate'
+        items[0].artist = 'alt-J'
+        items[0].albumartist = 'alt-J'
+        items[0].album = 'An Awesome Wave'
+        items[0].itunes_rating = 60
+
+        items[1].title = 'Breezeblocks'
+        items[1].artist = 'alt-J'
+        items[1].albumartist = 'alt-J'
+        items[1].album = 'An Awesome Wave'
+
+        for item in items:
+            self.lib.add(item)
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def test_load_item_types(self):
+        # This test also verifies that the MetaSources have loaded correctly
+        self.assertIn('amarok_score', Item._types)
+        self.assertIn('itunes_rating', Item._types)
+
+    def test_pretend_sync_from_itunes(self):
+        out = self.run_with_output('metasync', '-p')
+
+        self.assertIn('itunes_rating: 60 -> 80', out)
+        self.assertIn('itunes_rating: 100', out)
+        self.assertIn('itunes_playcount: 31', out)
+        self.assertIn('itunes_skipcount: 3', out)
+        self.assertIn('itunes_lastplayed: 2015-05-04 12:20:51', out)
+        self.assertIn('itunes_lastskipped: 2015-02-05 15:41:04', out)
+
+        self.assertEqual(self.lib.items()[0].itunes_rating, 60)
+
+    def test_sync_from_itunes(self):
+        self.run_command('metasync')
+
+        self.assertEqual(self.lib.items()[0].itunes_rating, 80)
+        self.assertEqual(self.lib.items()[0].itunes_playcount, 0)
+        self.assertEqual(self.lib.items()[0].itunes_skipcount, 3)
+        self.assertFalse(hasattr(self.lib.items()[0], 'itunes_lastplayed'))
+        self.assertEqual(self.lib.items()[0].itunes_lastskipped, 1423147264.0)
+
+        self.assertEqual(self.lib.items()[1].itunes_rating, 100)
+        self.assertEqual(self.lib.items()[1].itunes_playcount, 31)
+        self.assertEqual(self.lib.items()[1].itunes_skipcount, 0)
+        self.assertEqual(self.lib.items()[1].itunes_lastplayed, 1430734851.0)
+        self.assertFalse(hasattr(self.lib.items()[1], 'itunes_lastskipped'))
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == b'__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
Adds support for syncing iTunes metadata: *rating, play count, skip count, last played, last skipped*

It uses `plistlib`, which is available for all platforms (since py26), but the behavior is completely untested on Windows system (only tested on my OS X system). The iTunes library is copied to a temporary file before reading it, to avoid corrupting it.

Want to do a few more things, but figured I'd get it up here already (since it technically works).

- [x] Make more OO (e.g., like `FetchArt` and `ArtSources`)
- [x] Add extra logging in the MetaSources
- [x] Investigate behavior on Windows
- [x] Add tests
- [x] Expose `item_types` from the MetaSources

