### PR TITLE
Review request: add merging functionality to duplicates plugin

### DIFF
--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -42,6 +42,7 @@ class DuplicatesPlugin(BeetsPlugin):
             'format': '',
             'full': False,
             'keys': [],
+            'merge': False,
             'move': '',
             'path': False,
             'tiebreak': {},
@@ -81,6 +82,10 @@ class DuplicatesPlugin(BeetsPlugin):
                                         callback=vararg_callback,
                                         help='report duplicates based on keys')
 
+        self._command.parser.add_option('-M', '--merge', dest='merge',
+                                        action='store_true',
+                                        help='merge duplicate items')
+
         self._command.parser.add_option('-m', '--move', dest='move',
                                         action='store', metavar='DEST',
                                         help='move items to dest')
@@ -108,6 +113,7 @@ class DuplicatesPlugin(BeetsPlugin):
             fmt = self.config['format'].get(str)
             full = self.config['full'].get(bool)
             keys = self.config['keys'].get(list)
+            merge = self.config['merge'].get(bool)
             move = self.config['move'].get(str)
             path = self.config['path'].get(bool)
             tiebreak = self.config['tiebreak'].get(dict)
@@ -139,11 +145,12 @@ class DuplicatesPlugin(BeetsPlugin):
                     k, _ = self._checksum(i, checksum)
                 keys = [k]
 
-            for obj_id, obj_count, objs in self._duplicates(items,
+            for obj_id, obj_count, objs in self._duplicates(items, lib,
                                                             keys=keys,
                                                             full=full,
                                                             strict=strict,
-                                                            tiebreak=tiebreak):
+                                                            tiebreak=tiebreak,
+                                                            merge=merge):
                 if obj_id:  # Skip empty IDs.
                     for o in objs:
                         self._process_item(o, lib,
@@ -249,12 +256,59 @@ class DuplicatesPlugin(BeetsPlugin):
 
         return sorted(objs, key=key, reverse=True)
 
-    def _duplicates(self, objs, keys, full, strict, tiebreak):
+    def _merge_items(self, objs):
+        fields = [f for sublist in Item.get_fields() for f in sublist]
+        for f in fields:
+            for o in objs[1:]:
+                if getattr(objs[0], f, None) in (None, ''):
+                    value = getattr(o, f, None)
+                    if value:
+                        self._log.debug(u'key {0} on item {1} is null '
+                                        'or empty: setting from item {2}',
+                                        f, displayable_path(objs[0].path),
+                                        displayable_path(o.path))
+                        setattr(objs[0], f, value)
+                        objs[0].store()
+                        break
+                    else:
+                        continue
+        return objs
+
+    def _merge_albums(self, objs, lib):
+        ids = [i.mb_trackid for i in objs[0].items()]
+        for o in objs[1:]:
+            for i in o.items():
+                if i.mb_trackid not in ids:
+                    missing = Item.from_path(i.path)
+                    missing.album_id = objs[0].id
+                    self._log.debug(u'item {0} missing from album {1}:'
+                                    ' merging from {2} into {3}',
+                                    missing,
+                                    objs[0],
+                                    displayable_path(o.path),
+                                    displayable_path(missing.destination()))
+                    lib.add(missing)
+                    missing.move(copy=True)
+                    continue
+        return objs
+
+    def _merge(self, objs, lib):
+        """Merge duplicate items
+        """
+        kind = Item if all(isinstance(o, Item) for o in objs) else Album
+        if kind is Item:
+            objs = self._merge_items(objs)
+        else:
+            objs = self._merge_albums(objs, lib)
+        return objs
+
+    def _duplicates(self, objs, lib, keys, full, strict, tiebreak, merge):
         """Generate triples of keys, duplicate counts, and constituent objects.
         """
         offset = 0 if full else 1
         for k, objs in self._group_by(objs, keys, strict).iteritems():
             if len(objs) > 1:
-                yield (k,
-                       len(objs) - offset,
-                       self._order(objs, tiebreak)[offset:])
+                objs = self._order(objs, tiebreak)
+                if merge:
+                    objs = self._merge(objs, lib)
+                yield (k, len(objs) - offset, objs[offset:])


### PR DESCRIPTION
This patch is based on the ordering imposed by the tiebreaking facility
introduced in 6be98b0a369aa148acee8906d55076ac824b5108. Once a natural
duplicate ordering is in place, then the strategies for merging are:

Items
-----

    Iterate through each available field:
        Iterate through each duplicate:
            If current duplicate has a field not set in the original, set it there
            Break

This is, I believe, solved.

Albums
------

    Iterate through each duplicate:
        Iterate through each item in duplicate:
            If current item is not present in original, copy it there
            Continue

Problems:

What to use to check for identical items in the album merging logic:
currently I use mb_trackid; this is bound to break later on, or possibly
right away on some libraries that don't use musicbrainz, or have items
with not musicbrainz IDs.

I also don't completely understand how to cleanly move an item to a
different album.

Questions, comments, solutions welcome!