### PR TITLE
File modification note in docs

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -268,7 +268,10 @@ changes and file deletions.
 
 This will scan all the matched files and read their tags, populating the
 database with the new values. By default, files will be renamed according to
-their new metadata; disable this with ``-M``.
+their new metadata; disable this with ``-M``. Beets will skip files if their
+modification times have not changed, so any out-of-band metadata changes must
+also update these for ``beet update`` to recognise that the files have been
+edited.
 
 To perform a "dry run" of an update, just use the ``-p`` (for "pretend") flag.
 This will show you all the proposed changes but won't actually change anything


### PR DESCRIPTION
I couldn't get beet update to read metadata changes - turns out that puddletag
doesn't touch the file modification time by default. It's a perfectly sensible
behaviour but I thought I'd add a note in the `beet update` section in case
anyone else has this problem.