### PR TITLE
Use python-mpd2 instead of python-mpd. Fixes #1472.

### DIFF
--- a/docs/plugins/mpdstats.rst
+++ b/docs/plugins/mpdstats.rst
@@ -14,12 +14,12 @@ habits from `MPD`_.  It collects the following information about tracks:
 Installing Dependencies
 -----------------------
 
-This plugin requires the python-mpd library in order to talk to the MPD
+This plugin requires the python-mpd2 library in order to talk to the MPD
 server.
 
 Install the library from `pip`_, like so::
 
-    $ pip install python-mpd
+    $ pip install python-mpd2
 
 Add the ``mpdstats`` plugin to your configuration (see :ref:`using-plugins`).
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'responses',
         'pyxdg',
         'pathlib',
-        'python-mpd',
+        'python-mpd2',
     ],
 
     # Plugin (optional) dependencies:
@@ -115,7 +115,7 @@ setup(
         'discogs': ['discogs-client>=2.1.0'],
         'echonest': ['pyechonest'],
         'lastgenre': ['pylast'],
-        'mpdstats': ['python-mpd'],
+        'mpdstats': ['python-mpd2'],
         'web': ['flask', 'flask-cors'],
         'import': ['rarfile'],
         'thumbnails': ['pathlib', 'pyxdg'],

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pathlib
     pyxdg
     jellyfish
-    python-mpd
+    python-mpd2
 commands =
     nosetests {posargs}
 


### PR DESCRIPTION
note: `python-mpd2` uses the same library name used for `import`, it doesn't need to be changed.

Read #1472 for rationale.

In addition, there's [a strange segfault that pops up with this change](https://gist.github.com/Somasis/370b2166d377e255dbd7). I don't really do much python stuff, I just maintain `beets` for Exherbo Linux, so if anyone has an idea... not a very helpful error, though. I suspect it has something to do `mpdupdate`, since it only occurs at the end.
