### PR TITLE
Add newlines to autotag prompts to make them readable

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -131,7 +131,7 @@ def print_(*strings, **kwargs):
             txt = b' '.join(strings)
             txt += b'\n' if end is None else end
     else:
-        txt = u''
+        txt = u'\n'
 
     # Always send bytes to the stdout stream.
     if isinstance(txt, unicode):

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -673,7 +673,7 @@ class TerminalImportSession(importer.ImportSession):
         AlbumMatch object, ASIS, or SKIP.
         """
         # Show what we're tagging.
-        print_('\n')
+        print_()
         print_(displayable_path(task.paths, u'\n') +
                u' ({0} items)'.format(len(task.items)))
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -673,7 +673,7 @@ class TerminalImportSession(importer.ImportSession):
         AlbumMatch object, ASIS, or SKIP.
         """
         # Show what we're tagging.
-        print_()
+        print_('\n')
         print_(displayable_path(task.paths, u'\n') +
                u' ({0} items)'.format(len(task.items)))
 


### PR DESCRIPTION
This is simply a usability aid; before this, all autotag prompts are piled atop one another without any spacing in between.