### PR TITLE
Fix: ignored-list in match section is… ignored.

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -357,7 +357,7 @@ def _add_candidate(items, results, info):
     dist = distance(items, info, mapping)
 
     # Skip matches with ignored penalties.
-    penalties = [key for _, key in dist]
+    penalties = [key for key, _ in dist]
     for penalty in config['match']['ignored'].as_str_seq():
         if penalty in penalties:
             log.debug(u'Ignored. Penalty: {0}', penalty)


### PR DESCRIPTION
Hi there,

I just realized that the
```
match:
    ignored: unmatched_tracks
```
option didn't work for me [as described](http://beets.readthedocs.org/en/v1.3.13/reference/config.html#ignored). After looking into the source, I discovered that the list that is used to match ignored parameters, is filled with the `Distance` object's values instead of its keys. The PR should fix this.