### PR TITLE
Add support for pregap tracks

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -95,7 +95,11 @@ def apply_metadata(album_info, mapping):
         item.title = track_info.title
 
         if config['per_disc_numbering']:
-            item.track = track_info.medium_index or track_info.index
+            # We want to let the track number be zero, but if the medium index
+            # is not provided we need to fall back to the overall index.
+            item.track = track_info.medium_index
+            if item.track is None:
+                item.track = track_info.index
             item.tracktotal = track_info.medium_total or len(album_info.tracks)
         else:
             item.track = track_info.index

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -215,7 +215,12 @@ def album_info(release):
     for medium in release['medium-list']:
         disctitle = medium.get('title')
         format = medium.get('format')
-        for track in medium['track-list']:
+
+        all_tracks = medium['track-list']
+        if 'pregap' in medium:
+            all_tracks.insert(0, medium['pregap'])
+
+        for track in all_tracks:
             # Basic information from the recording.
             index += 1
             ti = track_info(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,7 @@ New features:
   and `min_width` options if no local imaging backend is available. :bug:`1460`
 * The `move` command has a new `-p/--pretend` option, making the command show
   how the items will be moved, without modifying the files on disk.
-
+* The importer now supports matching of pregap tracks in releases.
 
 Fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -233,7 +233,10 @@ A boolean controlling the track numbering style on multi-disc releases. By
 default (``per_disc_numbering: no``), tracks are numbered per-release, so the
 first track on the second disc has track number N+1 where N is the number of
 tracks on the first disc. If this ``per_disc_numbering`` is enabled, then the
-first track on each disc always has track number 1.
+first track on each disc always has track number 1. This is true even when the
+disc has pregap tracks, typically numbered 0 - in that case, the pregap track
+of the first disc has track number 1 and every other track has its original
+track number plus one.
 
 If you enable ``per_disc_numbering``, you will likely want to change your
 :ref:`path-format-config` also to include ``$disc`` before ``$track`` to make


### PR DESCRIPTION
This pull request adds support for pregap tracks in imports from Musicbrainz. This will only work after Musicbrainzngs releases a new version and beets starts using it, but everything should work as normal until then.

Two things to note:

* I opted to leave `track_info.index` starting at 1 even in the presence of pregap tracks, which means that users with `per_disc_numbering` deactivated will see the pregap track as track 1 and every other track as its "original" album track number plus one. In albums with a single disc that felt strange to me, but then I thought about albums with multiple discs and multiple pregap tracks - I could set the index of the pregap in the first disc as 0, but then I would have to go sequential from there, including other pregap tracks in the same release. As I thought that would be rather inconsistent I implemented as seen in this pull request, but suggestions would be welcome;
* I'm not that fluent in Python, so please tell me if there is a more efficient/pythonic way to do this :)

Fixes #1104.