### PR TITLE
PlexUpdate plugin updated for Plex Home

### DIFF
--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -1,5 +1,6 @@
 """Updates an Plex library whenever the beets library is changed.
-For Plex home users ensure that the token is filled out with the Plex Token for your user.
+
+Plex Home users enter the Plex Token to enable updating.
 Put something like the following in your config.yaml to configure:
     plex:
         host: localhost
@@ -37,7 +38,8 @@ def update_plex(host, port, token):
     """
     # Getting section key and build url.
     section_key = get_music_section(host, port, token)
-    api_endpoint = append_token('library/sections/{0}/refresh'.format(section_key), token)
+    api_endpoint = 'library/sections/{0}/refresh'.format(section_key)
+    api_endpoint = append_token(api_endpoint, token)
     url = urljoin('http://{0}:{1}'.format(host, port), api_endpoint)
 
     # Sends request and returns requests object.

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -12,6 +12,7 @@ from __future__ import (division, absolute_import, print_function,
 
 import requests
 from urlparse import urljoin
+from urllib import urlencode
 import xml.etree.ElementTree as ET
 from beets import config
 from beets.plugins import BeetsPlugin
@@ -51,7 +52,7 @@ def append_token(url, token):
     """Appends the Plex Home token to the api call if required.
     """
     if token:
-        url += '?X-Plex-Token={0}'.format(token)
+        url += '?' + urlencode({'X-Plex-Token': token})
     return url
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,8 @@ Fixes:
 * Fix a bug, where the autotagger still considers matches that are specifically
   listed under the config's ignored section. :bug:`1487`
 * Fix a bug with unicode strings when generating thumbnails. :bug:`1485`
+* :doc:`/plugins/plexupdate`: Fixed library updates not working when in a Plex
+  Home by allowing a token with requests.
 
 
 1.3.13 (April 24, 2015)

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -13,6 +13,9 @@ which looks like this::
     plex:
         host: localhost
         port: 32400
+        token: token
+
+Use the token configuration option only when in a Plex Home (see `Plex Token`_)
 
 To use the ``plexupdate`` plugin you need to install the `requests`_ library with:
 
@@ -23,6 +26,7 @@ server every time you change your beets library.
 
 .. _Plex: http://plex.tv/
 .. _requests: http://docs.python-requests.org/en/latest/
+.. _Plex Token: https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Token
 
 Configuration
 -------------
@@ -33,3 +37,5 @@ The available options under the ``plex:`` section are:
   Default: ``localhost``.
 - **port**: The Plex server port.
   Default: 32400.
+- **token**: The Plex Home token.
+  Default: Empty.

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -87,7 +87,8 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         # Test if section key is "2" out of the mocking data.
         self.assertEqual(get_music_section(
             self.config['plex']['host'],
-            self.config['plex']['port']), '2')
+            self.config['plex']['port'],
+            self.config['plex']['token']), '2')
 
     @responses.activate
     def test_update_plex(self):
@@ -98,7 +99,8 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         # Testing status code of the mocking request.
         self.assertEqual(update_plex(
             self.config['plex']['host'],
-            self.config['plex']['port']).status_code, 200)
+            self.config['plex']['port'],
+            self.config['plex']['token']).status_code, 200)
 
 
 def suite():


### PR DESCRIPTION
Updated the PlexUpdate plugin to allow Plex Tokens to be provided with the
server details so that beets can update a Plex library that requires
authentication.