### PR TITLE
Import only files which are not at the library

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -332,8 +332,22 @@ class ImportSession(object):
         if self.config['incremental'] \
            and tuple(paths) in self.history_dirs:
             return True
-
-        return False
+        for path in paths:
+            # In case path points to a directory: check if there is
+            # already an album at the library with the same path.
+            # If it's not a directory: check for already imported
+            # singletons.
+            if os.path.isdir(path):
+                items = self.lib.albums('path:"' + path + '"')
+            else:
+                items = self.lib.items('path:"' + path + '"')
+            if items is None or len(items) == 0:
+                # This path is not found at the library so it isn't
+                # already imported.
+                return False
+        # All paths are present at the library so everything was
+        # already imported before.
+        return True
 
     @property
     def history_dirs(self):


### PR DESCRIPTION
With this change, the importer will skip all files, which are already at the library. This is helpful if you import the whole library again to add files which are placed there after the last import. I made this the default behavior, but we could easily add an command line or configuration option to turn it on or off.

What do you think about it?