### PR TITLE
#872: Tag change hooks

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -511,10 +511,7 @@ def album_for_mbid(release_id):
     if the ID is not found.
     """
     try:
-        album = mb.album_for_id(release_id)
-        if album:
-            plugins.send('albuminfo_received', info=album)
-        return album
+        return mb.album_for_id(release_id)
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -524,10 +521,7 @@ def track_for_mbid(recording_id):
     if the ID is not found.
     """
     try:
-        track = mb.track_for_id(recording_id)
-        if track:
-            plugins.send('trackinfo_received', info=track)
-        return track
+        return mb.track_for_id(recording_id)
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -535,20 +529,18 @@ def track_for_mbid(recording_id):
 def albums_for_id(album_id):
     """Get a list of albums for an ID."""
     candidates = [album_for_mbid(album_id)]
-    plugin_albums = plugins.album_for_id(album_id)
-    for a in plugin_albums:
-        plugins.send('trackinfo_received', info=a)
-    candidates.extend(plugin_albums)
+    candidates.extend(plugins.album_for_id(album_id))
+    for a in candidates:
+        plugins.send('albuminfo_received', info=a)
     return filter(None, candidates)
 
 
 def tracks_for_id(track_id):
     """Get a list of tracks for an ID."""
     candidates = [track_for_mbid(track_id)]
-    plugin_tracks = plugins.track_for_id(track_id)
-    for t in plugin_tracks:
+    candidates.extend(plugins.track_for_id(track_id))
+    for t in candidates:
         plugins.send('trackinfo_received', info=t)
-    candidates.extend(plugin_tracks)
     return filter(None, candidates)
 
 
@@ -578,10 +570,6 @@ def album_candidates(items, artist, album, va_likely):
     # Candidates from plugins.
     out.extend(plugins.candidates(items, artist, album, va_likely))
 
-    # Notify subscribed plugins about fetched album info
-    for a in out:
-        plugins.send('albuminfo_received', info=a)
-
     return out
 
 
@@ -601,9 +589,5 @@ def item_candidates(item, artist, title):
 
     # Plugin candidates.
     out.extend(plugins.item_candidates(item, artist, title))
-
-    # Notify subscribed plugins about fetched album info
-    for i in out:
-        plugins.send('trackinfo_received', info=i)
 
     return out

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -511,7 +511,10 @@ def album_for_mbid(release_id):
     if the ID is not found.
     """
     try:
-        return mb.album_for_id(release_id)
+        album = mb.album_for_id(release_id)
+        if album:
+            plugins.send('albuminfo_received', info=album)
+        return album
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -521,7 +524,10 @@ def track_for_mbid(recording_id):
     if the ID is not found.
     """
     try:
-        return mb.track_for_id(recording_id)
+        track = mb.track_for_id(recording_id)
+        if track:
+            plugins.send('trackinfo_received', info=track)
+        return track
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -529,14 +535,20 @@ def track_for_mbid(recording_id):
 def albums_for_id(album_id):
     """Get a list of albums for an ID."""
     candidates = [album_for_mbid(album_id)]
-    candidates.extend(plugins.album_for_id(album_id))
+    plugin_albums = plugins.album_for_id(album_id)
+    for a in plugin_albums:
+        plugins.send('trackinfo_received', info=a)
+    candidates.extend(plugin_albums)
     return filter(None, candidates)
 
 
 def tracks_for_id(track_id):
     """Get a list of tracks for an ID."""
     candidates = [track_for_mbid(track_id)]
-    candidates.extend(plugins.track_for_id(track_id))
+    plugin_tracks = plugins.track_for_id(track_id)
+    for t in plugin_tracks:
+        plugins.send('trackinfo_received', info=t)
+    candidates.extend(plugin_tracks)
     return filter(None, candidates)
 
 
@@ -566,6 +578,10 @@ def album_candidates(items, artist, album, va_likely):
     # Candidates from plugins.
     out.extend(plugins.candidates(items, artist, album, va_likely))
 
+    # Notify subscribed plugins about fetched album info
+    for a in out:
+        plugins.send('albuminfo_received', info=a)
+
     return out
 
 
@@ -585,5 +601,9 @@ def item_candidates(item, artist, title):
 
     # Plugin candidates.
     out.extend(plugins.item_candidates(item, artist, title))
+
+    # Notify subscribed plugins about fetched album info
+    for i in out:
+        plugins.send('trackinfo_received', info=i)
 
     return out

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -530,8 +530,6 @@ def albums_for_id(album_id):
     """Get a list of albums for an ID."""
     candidates = [album_for_mbid(album_id)]
     candidates.extend(plugins.album_for_id(album_id))
-    for a in candidates:
-        plugins.send('albuminfo_received', info=a)
     return filter(None, candidates)
 
 
@@ -539,8 +537,6 @@ def tracks_for_id(track_id):
     """Get a list of tracks for an ID."""
     candidates = [track_for_mbid(track_id)]
     candidates.extend(plugins.track_for_id(track_id))
-    for t in candidates:
-        plugins.send('trackinfo_received', info=t)
     return filter(None, candidates)
 
 

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -511,7 +511,10 @@ def album_for_mbid(release_id):
     if the ID is not found.
     """
     try:
-        return mb.album_for_id(release_id)
+        album = mb.album_for_id(release_id)
+        if album:
+            plugins.send('albuminfo_received', info=album)
+        return album
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -521,7 +524,10 @@ def track_for_mbid(recording_id):
     if the ID is not found.
     """
     try:
-        return mb.track_for_id(recording_id)
+        track = mb.track_for_id(recording_id)
+        if track:
+            plugins.send('trackinfo_received', info=track)
+        return track
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -529,14 +535,20 @@ def track_for_mbid(recording_id):
 def albums_for_id(album_id):
     """Get a list of albums for an ID."""
     candidates = [album_for_mbid(album_id)]
-    candidates.extend(plugins.album_for_id(album_id))
+    plugin_albums = plugins.album_for_id(album_id)
+    for a in plugin_albums:
+        plugins.send('albuminfo_received', info=a)
+    candidates.extend(plugin_albums)
     return filter(None, candidates)
 
 
 def tracks_for_id(track_id):
     """Get a list of tracks for an ID."""
     candidates = [track_for_mbid(track_id)]
-    candidates.extend(plugins.track_for_id(track_id))
+    plugin_tracks = plugins.track_for_id(track_id)
+    for t in plugin_tracks:
+        plugins.send('trackinfo_received', info=t)
+    candidates.extend(plugin_tracks)
     return filter(None, candidates)
 
 
@@ -566,6 +578,10 @@ def album_candidates(items, artist, album, va_likely):
     # Candidates from plugins.
     out.extend(plugins.candidates(items, artist, album, va_likely))
 
+    # Notify subscribed plugins about fetched album info
+    for a in out:
+        plugins.send('albuminfo_received', info=a)
+
     return out
 
 
@@ -585,5 +601,9 @@ def item_candidates(item, artist, title):
 
     # Plugin candidates.
     out.extend(plugins.item_candidates(item, artist, title))
+
+    # Notify subscribed plugins about fetched track info
+    for i in out:
+        plugins.send('trackinfo_received', info=i)
 
     return out

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -350,6 +350,10 @@ def _add_candidate(items, results, info):
             log.debug(u'Ignored. Missing required tag: {0}', req_tag)
             return
 
+    # Notify subscribed plugins about fetched album info and let them perform
+    # their manipulations
+    plugins.send('albuminfo_received', info=info)
+
     # Find mapping between the items and the track info.
     mapping, extra_items, extra_tracks = assign_items(items, info.tracks)
 
@@ -459,6 +463,10 @@ def tag_item(item, search_artist=None, search_title=None,
     if trackid:
         log.debug(u'Searching for track ID: {0}', trackid)
         for track_info in hooks.tracks_for_id(trackid):
+            # Notify subscribed plugins about fetched track info and let them perform
+            # their manipulations
+            plugins.send('trackinfo_received', info=track_info)
+
             dist = track_distance(item, track_info, incl_artist=True)
             candidates[track_info.track_id] = \
                 hooks.TrackMatch(dist, track_info)
@@ -482,6 +490,10 @@ def tag_item(item, search_artist=None, search_title=None,
 
     # Get and evaluate candidate metadata.
     for track_info in hooks.item_candidates(item, search_artist, search_title):
+        # Notify subscribed plugins about fetched track info and let them perform
+        # their manipulations
+        plugins.send('trackinfo_received', info=track_info)
+
         dist = track_distance(item, track_info, incl_artist=True)
         candidates[track_info.track_id] = hooks.TrackMatch(dist, track_info)
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -463,8 +463,8 @@ def tag_item(item, search_artist=None, search_title=None,
     if trackid:
         log.debug(u'Searching for track ID: {0}', trackid)
         for track_info in hooks.tracks_for_id(trackid):
-            # Notify subscribed plugins about fetched track info and let them perform
-            # their manipulations
+            # Notify subscribed plugins about fetched track info and let them
+            # perform their manipulations
             plugins.send('trackinfo_received', info=track_info)
 
             dist = track_distance(item, track_info, incl_artist=True)
@@ -490,8 +490,8 @@ def tag_item(item, search_artist=None, search_title=None,
 
     # Get and evaluate candidate metadata.
     for track_info in hooks.item_candidates(item, search_artist, search_title):
-        # Notify subscribed plugins about fetched track info and let them perform
-        # their manipulations
+        # Notify subscribed plugins about fetched track info and let them
+        # perform their manipulations
         plugins.send('trackinfo_received', info=track_info)
 
         dist = track_distance(item, track_info, incl_artist=True)

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -350,10 +350,6 @@ def _add_candidate(items, results, info):
             log.debug(u'Ignored. Missing required tag: {0}', req_tag)
             return
 
-    # Notify subscribed plugins about fetched album info and let them perform
-    # their manipulations
-    plugins.send('albuminfo_received', info=info)
-
     # Find mapping between the items and the track info.
     mapping, extra_items, extra_tracks = assign_items(items, info.tracks)
 
@@ -463,10 +459,6 @@ def tag_item(item, search_artist=None, search_title=None,
     if trackid:
         log.debug(u'Searching for track ID: {0}', trackid)
         for track_info in hooks.tracks_for_id(trackid):
-            # Notify subscribed plugins about fetched track info and let them
-            # perform their manipulations
-            plugins.send('trackinfo_received', info=track_info)
-
             dist = track_distance(item, track_info, incl_artist=True)
             candidates[track_info.track_id] = \
                 hooks.TrackMatch(dist, track_info)
@@ -490,10 +482,6 @@ def tag_item(item, search_artist=None, search_title=None,
 
     # Get and evaluate candidate metadata.
     for track_info in hooks.item_candidates(item, search_artist, search_title):
-        # Notify subscribed plugins about fetched track info and let them
-        # perform their manipulations
-        plugins.send('trackinfo_received', info=track_info)
-
         dist = track_distance(item, track_info, incl_artist=True)
         candidates[track_info.track_id] = hooks.TrackMatch(dist, track_info)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -125,6 +125,10 @@ The new features:
   :bug:`1104` :bug:`1493`
 * :doc:`/plugins/plexupdate`: A new ``token`` configuration option lets you
   specify a key for Plex Home setups. Thanks to :user:`edcarroll`. :bug:`1494`
+* :doc:`/dev/plugins`: New hooks ``albuminfo_received`` and
+  ``trackinfo_received`` have been added for developers who would like to
+  intercept fetched meta data, before they are applied in tag manipulation
+  operations. :bug:`872`
 
 Fixes:
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -217,9 +217,9 @@ The events currently available are:
 * *trackinfo_received*: called after meta data for a track item has been fetched
   from disparate sources, such as MusicBrainz. Gives a developer the option to
   intercept the fetched TrackInfo object. Can be used to modify tags on a ``beet
-  import`` operation or during later adjustments, such as ``mbsync``. Can be
-  slow, as event is fired for any fetched possible match *before* user or
-  autotagger selection was made.
+  import`` operation or during later adjustments, such as ``mbsync``. Slow
+  handlers of the event can impact the operation, since the event is fired for
+  any fetched possible match *before* user or autotagger selection was made.
   Parameter: ``info``.
 
 * *albuminfo_received*: Like *trackinfo_received*, the event indicates new meta

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -216,15 +216,16 @@ The events currently available are:
 
 * *trackinfo_received*: called after meta data for a track item has been fetched
   from disparate sources, such as MusicBrainz. Gives a developer the option to
-  intercept the fetched TrackInfo object. Can be used to modify tags on a ``beet
-  import`` operation or during later adjustments, such as ``mbsync``. Slow
-  handlers of the event can impact the operation, since the event is fired for
-  any fetched possible match *before* user or autotagger selection was made.
+  intercept the fetched ``TrackInfo`` object. Can be used to modify tags on a
+  ``beet import`` operation or during later adjustments, such as ``mbsync``.
+  Slow handlers of the event can impact the operation, since the event is fired
+  for any fetched possible match *before* user or autotagger selection was made.
   Parameter: ``info``.
 
 * *albuminfo_received*: Like *trackinfo_received*, the event indicates new meta
-  data for album items, but supplies an *AlbumInfo* object instead of a
-  *TrackInfo*.
+  data for album items, but supplies an ``AlbumInfo`` object instead of a
+  ``TrackInfo``.
+  Parameter: ``info``.
 
 The included ``mpdupdate`` plugin provides an example use case for event listeners.
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -222,13 +222,9 @@ The events currently available are:
   autotagger selection was made.
   Parameter: ``info``.
 
-* *albuminfo_received*: called after meta data for an album item has been
-  fetched from disparate sources, such as MusicBrainz. Gives a developer the
-  option to intercept the fetched AlbumInfo object. Can be used to modify tags
-  on a ``beet import`` operation or during later adjustments, such as
-  ``mbsync``. Can be slow, as event is fired for any fetched possible match
-  *before* user or autotagger selection was made.
-  Parameter: ``info``.
+* *albuminfo_received*: Like *trackinfo_received*, the event indicates new meta
+  data for album items, but supplies an *AlbumInfo* object instead of a
+  *TrackInfo*.
 
 The included ``mpdupdate`` plugin provides an example use case for event listeners.
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -214,6 +214,22 @@ The events currently available are:
 * *import_begin*: called just before a ``beet import`` session starts up.
   Parameter: ``session``.
 
+* *trackinfo_received*: called after meta data for a track item has been fetched
+  from disparate sources, such as MusicBrainz. Gives a developer the option to
+  intercept the fetched TrackInfo object. Can be used to modify tags on a ``beet
+  import`` operation or during later adjustments, such as ``mbsync``. Can be
+  slow, as event is fired for any fetched possible match *before* user or
+  autotagger selection was made.
+  Parameter: ``info``.
+
+* *albuminfo_received*: called after meta data for an album item has been
+  fetched from disparate sources, such as MusicBrainz. Gives a developer the
+  option to intercept the fetched AlbumInfo object. Can be used to modify tags
+  on a ``beet import`` operation or during later adjustments, such as
+  ``mbsync``. Can be slow, as event is fired for any fetched possible match
+  *before* user or autotagger selection was made.
+  Parameter: ``info``.
+
 The included ``mpdupdate`` plugin provides an example use case for event listeners.
 
 Extend the Autotagger


### PR DESCRIPTION
This PR adds the new hooks `albuminfo_received` and `trackinfo_received` for developers who would like to intercept fetched meta data, before they are applied in tag manipulation operations. See #872 