### PR TITLE
Make the -f/--format option work with the ls command again.

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -975,7 +975,7 @@ def list_items(lib, query, album, fmt=''):
 
 
 def list_func(lib, opts, args):
-    list_items(lib, decargs(args), opts.album)
+    list_items(lib, decargs(args), opts.album, opts.format)
 
 
 list_cmd = ui.Subcommand('list', help='query the library', aliases=('ls',))


### PR DESCRIPTION
Put this into a pull request because I'm not entirely sure this is the right solution after `--format` refactoring.