### PR TITLE
fix auto-grouping

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1408,7 +1408,8 @@ def group_albums(session):
         if task.skip:
             continue
         tasks = []
-        for _, items in itertools.groupby(sorted(task.items, key=group), group):
+        sorted_items = sorted(task.items, key=group)
+        for _, items in itertools.groupby(sorted_items, group):
             items = list(items)
             task = ImportTask(task.toppath, [i.path for i in items],
                               items)

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1408,7 +1408,7 @@ def group_albums(session):
         if task.skip:
             continue
         tasks = []
-        for _, items in itertools.groupby(task.items, group):
+        for _, items in itertools.groupby(sorted(task.items,key=group), group):
             items = list(items)
             task = ImportTask(task.toppath, [i.path for i in items],
                               items)

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1408,7 +1408,7 @@ def group_albums(session):
         if task.skip:
             continue
         tasks = []
-        for _, items in itertools.groupby(sorted(task.items,key=group), group):
+        for _, items in itertools.groupby(sorted(task.items, key=group), group):
             items = list(items)
             task = ImportTask(task.toppath, [i.path for i in items],
                               items)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -77,6 +77,8 @@ Fixes:
   on the user's path by default).
 * Fix an incompatibility with certain JPEG files. Here's a relevant `Python
   bug`_. Thanks to :user:`nathdwek`. :bug:`1545`
+* Fix the 'Group albums' feature so it can handle when files aren't already
+  in order by album. :bug:`1550`
 
 .. _Python bug: http://bugs.python.org/issue16512
 


### PR DESCRIPTION
The auto-grouper only worked if the filenames in the directory happened to already be in order by artist & album.  Now, the code will first sort by artist & album, then group them.