### PR TITLE
Added TypeError to the list of caught exceptions in fetachart._fetch_…

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -436,7 +436,7 @@ class FetchArtPlugin(plugins.BeetsPlugin):
                 self._log.debug(u'downloaded art to: {0}',
                                 util.displayable_path(fh.name))
                 return fh.name
-        except (IOError, requests.RequestException):
+        except (IOError, requests.RequestException, TypeError):
             self._log.debug(u'error fetching art')
 
     def _is_valid_image_candidate(self, candidate):


### PR DESCRIPTION
…image

requests/urllib3 is throwing an exception due to an internal problem triggered
by some sort of timeout. This change catches the TypeError so that beets
reports "error fetching art" instead of crashing when this happens.

This fixes #1555