### PR TITLE
Rewrite the clearart method in order to send write events to the plugins.

### DIFF
--- a/beets/art.py
+++ b/beets/art.py
@@ -194,4 +194,4 @@ def clear(log, lib, query):
     log.info(u'Clearing album art from {0} items', len(items))
     for item in items:
         log.debug(u'Clearing art for {0}', item)
-        item.try_write(path=item.path, tags={'images': None})
+        item.try_write(tags={'images': None})

--- a/beets/art.py
+++ b/beets/art.py
@@ -26,6 +26,7 @@ from beets.util import displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 from beets import mediafile
 from beets import config
+from beets import plugins
 
 
 def mediafile_image(image_path, maxwidth=None):
@@ -205,3 +206,4 @@ def clear(log, lib, query):
         else:
             del mf.art
             mf.save()
+        plugins.send('after_write', item=item, path=item.path)

--- a/beets/art.py
+++ b/beets/art.py
@@ -25,8 +25,6 @@ import os
 from beets.util import displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 from beets import mediafile
-from beets import config
-from beets import plugins
 
 
 def mediafile_image(image_path, maxwidth=None):
@@ -192,18 +190,8 @@ def extract_first(log, outpath, items):
 
 
 def clear(log, lib, query):
-    id3v23 = config['id3v23'].get(bool)
-
     items = lib.items(query)
     log.info(u'Clearing album art from {0} items', len(items))
     for item in items:
         log.debug(u'Clearing art for {0}', item)
-        try:
-            mf = mediafile.MediaFile(syspath(item.path), id3v23)
-        except mediafile.UnreadableFileError as exc:
-            log.warning(u'Could not read file {0}: {1}',
-                        displayable_path(item.path), exc)
-        else:
-            del mf.art
-            mf.save()
-        plugins.send('after_write', item=item, path=item.path)
+        item.try_write(path=item.path, tags={'images': None})

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ Fixes:
 
 * :doc:`/plugins/lastgenre`: Fix a bug that prevented tag popularity from
   being considered. Thanks to :user:`svoos`. :bug:`1559`
+* Fixed a bug where plugins wouldn't be notified of the deletion of an item's
+  art, for example with the ``clearart`` command from the
+  :doc:`/plugins/embedart`. Thanks to :user:`nathdwek`. :bug:`1565`
 
 
 1.3.14 (August 2, 2015)


### PR DESCRIPTION
Currently, `beet clearart` doesn't notify plugins that some files are modified. This can be a problem when for example using the beets-check plugin because checksums aren't recomputed and the modified files are then detected as not intact during subsequent operations.

I finally settled on fixing this by using the try_write method which allows to simplify the code and centralizes the event sending so that this functionality isn't left out in the future. However, by doing that, `beet clearart` doesn't delete the image tag, but just erases its value. I don't know if this could be an issue.

The beets-check plugin is the only one I know which needs to be aware of a `beet clearart` operation so I don't know if I can write tests for this. Can external plugins be called in the test suite? 