### PR TITLE
play: make the many files warning configurable

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -40,6 +40,7 @@ class PlayPlugin(BeetsPlugin):
             'use_folders': False,
             'relative_to': None,
             'raw': False,
+            'warning_treshold': 100,
         })
 
     def commands(self):
@@ -64,6 +65,7 @@ class PlayPlugin(BeetsPlugin):
         use_folders = config['play']['use_folders'].get(bool)
         relative_to = config['play']['relative_to'].get()
         raw = config['play']['raw'].get(bool)
+        warning_treshold = config['play']['warning_treshold'].get(int)
         if relative_to:
             relative_to = util.normpath(relative_to)
 
@@ -105,7 +107,7 @@ class PlayPlugin(BeetsPlugin):
             return
 
         # Warn user before playing any huge playlists.
-        if len(selection) > 100:
+        if warning_treshold and len(selection) > warning_treshold:
             ui.print_(ui.colorize(
                 'text_warning',
                 'You are about to queue {0} {1}.'.format(len(selection),

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -38,7 +38,7 @@ configuration file. The available options are:
 - **command**: The command used to open the playlist.
   Default: ``open`` on OS X, ``xdg-open`` on other Unixes and ``start`` on
   Windows. Insert ``{}`` to make use of the ``--args``-feature.
-- **relative_to**: Emit paths relative to base directory.
+- **relative_to**: If set, emit paths relative to this directory.
   Default: None.
 - **use_folders**: When using the ``-a`` option, the m3u will contain the
   paths to each track on the matched albums. Enable this option to
@@ -47,6 +47,9 @@ configuration file. The available options are:
 - **raw**: Instead of creating a temporary m3u playlist and then opening it,
   simply call the command with the paths returned by the query as arguments.
   Default: ``no``.
+- **warning_treshold**: Set the minimum number of files to play which will
+  trigger a warning to be emitted. If set to ``no``, warning are never issued.
+  Default: 100.
 
 Optional Arguments
 ------------------


### PR DESCRIPTION
The warning_treshold key in the play configuration defines the
minimum number of file before a warning is issued (default 100).
A zero value means no warning is ever issued.

Tests are coming. Could you just confirm this is an OK-to-have feature?