### PR TITLE
beets-play: Add the option to pass the "raw" queried pathes to the player command

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1485,7 +1485,7 @@ def config_edit():
     try:
         if not os.path.isfile(path):
             open(path, 'w+').close()
-        util.interactive_open(path, editor)
+        util.interactive_open([path], editor)
     except OSError as exc:
         message = "Could not edit configuration: {0}".format(exc)
         if not editor:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -735,7 +735,7 @@ def open_anything():
     return base_cmd
 
 
-def interactive_open(target, command=None):
+def interactive_open(target=None, command=None, multiple_targets=[]):
     """Open the file `target` by `exec`ing a new command. (The new
     program takes over, and Python execution ends: this does not fork a
     subprocess.)
@@ -756,6 +756,8 @@ def interactive_open(target, command=None):
     else:
         base_cmd = open_anything()
         command = [base_cmd, base_cmd]
-
-    command.append(target)
+    if multiple_targets:
+        command = command + multiple_targets
+    else:
+        command.append(target)
     return os.execlp(*command)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -735,7 +735,7 @@ def open_anything():
     return base_cmd
 
 
-def interactive_open(target=None, command=None, multiple_targets=[]):
+def interactive_open(targets, command=None):
     """Open the file `target` by `exec`ing a new command. (The new
     program takes over, and Python execution ends: this does not fork a
     subprocess.)
@@ -756,8 +756,7 @@ def interactive_open(target=None, command=None, multiple_targets=[]):
     else:
         base_cmd = open_anything()
         command = [base_cmd, base_cmd]
-    if multiple_targets:
-        command = command + multiple_targets
-    else:
-        command.append(target)
+
+    command += targets
+
     return os.execlp(*command)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -736,7 +736,7 @@ def open_anything():
 
 
 def interactive_open(targets, command=None):
-    """Open the file `target` by `exec`ing a new command. (The new
+    """Open the files in `targets` by `exec`ing a new command. (The new
     program takes over, and Python execution ends: this does not fork a
     subprocess.)
 

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -117,14 +117,15 @@ class PlayPlugin(BeetsPlugin):
 
         ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
         if raw:
-            passedToCommand = self._concatenatePaths(paths)
+            passedToCommand = paths
         else:
             passedToCommand, m3u = self._createTmpPlaylist(paths)
 
         self._log.debug('executing command: {} {}', command_str,
                         passedToCommand)
         try:
-            util.interactive_open(passedToCommand, command_str)
+            util.interactive_open(multiple_targets=passedToCommand,
+                                  command=command_str)
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
                                "{0}".format(exc))
@@ -138,8 +139,4 @@ class PlayPlugin(BeetsPlugin):
         for item in pathsList:
             m3u.write(item + b'\n')
         m3u.close()
-        return m3u.name, m3u
-
-    def _concatenatePaths(self, pathsList):
-        concatenatedPaths = b'"' + b'" "'.join(pathsList) + b'"'
-        return concatenatedPaths
+        return [m3u.name], m3u

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -119,19 +119,20 @@ class PlayPlugin(BeetsPlugin):
         if raw:
             passed_to_command = paths
         else:
-            passed_to_command, m3u = self._create_tmp_playlist(paths)
+            passed_to_command = self._create_tmp_playlist(paths)
 
         self._log.debug('executing command: {} {}', command_str,
-                        passed_to_command)
+                        b'"' + b' '.join(passed_to_command) + b'"')
         try:
-            util.interactive_open(multiple_targets=passed_to_command,
-                                  command=command_str)
+            util.interactive_open(passed_to_command, command_str)
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
                                "{0}".format(exc))
         finally:
             if not raw:
-                util.remove(m3u.name)
+                self._log.debug('Removing temporary playlist: {}',
+                                passed_to_command[0])
+                util.remove(passed_to_command[0])
 
     def _create_tmp_playlist(self, paths_list):
         # Create temporary m3u file to hold our playlist.
@@ -139,4 +140,4 @@ class PlayPlugin(BeetsPlugin):
         for item in paths_list:
             m3u.write(item + b'\n')
         m3u.close()
-        return [m3u.name], m3u
+        return [m3u.name]

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -39,6 +39,7 @@ class PlayPlugin(BeetsPlugin):
             'command': None,
             'use_folders': False,
             'relative_to': None,
+            'raw': False,
         })
 
     def commands(self):
@@ -62,6 +63,7 @@ class PlayPlugin(BeetsPlugin):
         command_str = config['play']['command'].get()
         use_folders = config['play']['use_folders'].get(bool)
         relative_to = config['play']['relative_to'].get()
+        raw = config['play']['raw'].get(bool)
         if relative_to:
             relative_to = util.normpath(relative_to)
 
@@ -91,6 +93,8 @@ class PlayPlugin(BeetsPlugin):
         else:
             selection = lib.items(ui.decargs(args))
             paths = [item.path for item in selection]
+            if relative_to:
+                paths = [relpath(path, relative_to) for path in paths]
             item_type = 'track'
 
         item_type += 's' if len(selection) > 1 else ''
@@ -111,22 +115,31 @@ class PlayPlugin(BeetsPlugin):
             if ui.input_options(('Continue', 'Abort')) == 'a':
                 return
 
-        # Create temporary m3u file to hold our playlist.
-        m3u = NamedTemporaryFile('w', suffix='.m3u', delete=False)
-        for item in paths:
-            if relative_to:
-                m3u.write(relpath(item, relative_to) + b'\n')
-            else:
-                m3u.write(item + b'\n')
-        m3u.close()
-
         ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
+        if raw:
+            passedToCommand = self._concatenatePaths(paths)
+        else:
+            passedToCommand, m3u = self._createTmpPlaylist(paths)
 
-        self._log.debug('executing command: {} {}', command_str, m3u.name)
+        self._log.debug('executing command: {} {}', command_str,
+                        passedToCommand)
         try:
-            util.interactive_open(m3u.name, command_str)
+            util.interactive_open(passedToCommand, command_str)
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
                                "{0}".format(exc))
         finally:
-            util.remove(m3u.name)
+            if not raw:
+                util.remove(m3u.name)
+
+    def _createTmpPlaylist(self, pathsList):
+        # Create temporary m3u file to hold our playlist.
+        m3u = NamedTemporaryFile('w', suffix='.m3u', delete=False)
+        for item in pathsList:
+            m3u.write(item + b'\n')
+        m3u.close()
+        return m3u.name, m3u
+
+    def _concatenatePaths(self, pathsList):
+        concatenatedPaths = b'"' + b'" "'.join(pathsList) + b'"'
+        return concatenatedPaths

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -117,22 +117,22 @@ class PlayPlugin(BeetsPlugin):
 
         ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
         if raw:
-            passed_to_command = paths
+            open_args = paths
         else:
-            passed_to_command = self._create_tmp_playlist(paths)
+            open_args = self._create_tmp_playlist(paths)
 
         self._log.debug('executing command: {} {}', command_str,
-                        b'"' + b' '.join(passed_to_command) + b'"')
+                        b'"' + b' '.join(open_args) + b'"')
         try:
-            util.interactive_open(passed_to_command, command_str)
+            util.interactive_open(open_args, command_str)
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
                                "{0}".format(exc))
         finally:
             if not raw:
                 self._log.debug('Removing temporary playlist: {}',
-                                passed_to_command[0])
-                util.remove(passed_to_command[0])
+                                open_args[0])
+                util.remove(open_args[0])
 
     def _create_tmp_playlist(self, paths_list):
         # Create temporary m3u file to hold our playlist.

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -117,14 +117,14 @@ class PlayPlugin(BeetsPlugin):
 
         ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
         if raw:
-            passedToCommand = paths
+            passed_to_command = paths
         else:
-            passedToCommand, m3u = self._createTmpPlaylist(paths)
+            passed_to_command, m3u = self._create_tmp_playlist(paths)
 
         self._log.debug('executing command: {} {}', command_str,
-                        passedToCommand)
+                        passed_to_command)
         try:
-            util.interactive_open(multiple_targets=passedToCommand,
+            util.interactive_open(multiple_targets=passed_to_command,
                                   command=command_str)
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
@@ -133,10 +133,10 @@ class PlayPlugin(BeetsPlugin):
             if not raw:
                 util.remove(m3u.name)
 
-    def _createTmpPlaylist(self, pathsList):
+    def _create_tmp_playlist(self, paths_list):
         # Create temporary m3u file to hold our playlist.
         m3u = NamedTemporaryFile('w', suffix='.m3u', delete=False)
-        for item in pathsList:
+        for item in paths_list:
             m3u.write(item + b'\n')
         m3u.close()
         return [m3u.name], m3u

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -44,6 +44,9 @@ configuration file. The available options are:
   paths to each track on the matched albums. Enable this option to
   store paths to folders instead.
   Default: ``no``.
+- **raw**: Instead of creating a temporary m3u playlist and then opening it,
+  simply call the command with the paths returned by the query as arguments.
+  Default: ``no``.
 
 Optional Arguments
 ------------------

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -43,11 +43,11 @@ class UtilTest(unittest.TestCase):
     @patch('beets.util.open_anything')
     def test_interactive_open(self, mock_open, mock_execlp):
         mock_open.return_value = 'tagada'
-        util.interactive_open('foo')
+        util.interactive_open(['foo'])
         mock_execlp.assert_called_once_with('tagada', 'tagada', 'foo')
         mock_execlp.reset_mock()
 
-        util.interactive_open('foo', 'bar')
+        util.interactive_open(['foo'], 'bar')
         mock_execlp.assert_called_once_with('bar', 'bar', 'foo')
 
     def test_sanitize_unix_replaces_leading_dot(self):


### PR DESCRIPTION
I slightly rewrote the play plugin in order to improve the readability and to introduce the "raw" play config option which makes beet simply pass a list of paths to the play command rather than a playlist.

This possibility is useful because [vlc doesn't automatically expand (m3u) playlist files added to the (vlc) playlist](https://forum.videolan.org/viewtopic.php?f=7&t=92840) ([other topics about this issue](https://forum.videolan.org/search.php?keywords=expand+playlist)). Which means that if you intend to use `beet play` several times in a row, either you have to use the `--no-playlist-enqueue` vlc option which means that playback will be interrupted, either the temporary playlist created by beets will probably never be read and expanded.

This PR bypasses this issue by simply giving the option to pass the files directly as arguments to the configured command, which in this use-case, allows uninterrupted vlc playback while giving every track its chance to shine (yay!).

For this to work I also had to slightly modify `beets.util.interactive_open`. I'm quite sure I kept it backwards compatible and the only other call, by `beet config -e` still works perfecly.