### PR TITLE
removed obsolet variable from PR #1582

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -693,7 +693,6 @@ class CommonOptionsParser(optparse.OptionParser, object):
         # this serves both as an indicator that we offer the feature AND allows
         # us to check whether it has been specified on the CLI - bypassing the
         # fact that arguments may be in any order
-        self._added_help = False
 
     def add_album_option(self, flags=('-a', '--album')):
         """Add a -a/--album option to match albums instead of tracks.


### PR DESCRIPTION
Hi,

if the extra method introduced with 7a8765a would keep the object-oriented interface. But as it was removed, the extra variable can also be removed