### PR TITLE
A robust way to check for a case sensitive file system

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -61,9 +61,8 @@ class PathQuery(dbcore.FieldQuery):
         """
         super(PathQuery, self).__init__(field, pattern, fast)
 
-        # By default, the case sensitivity depends on the platform.
         if case_sensitive is None:
-            case_sensitive = platform.system() != 'Windows'
+            case_sensitive = self.is_filesystem_case_sensitive()
         self.case_sensitive = case_sensitive
 
         # Use a normalized-case pattern for case-insensitive matches.
@@ -74,6 +73,16 @@ class PathQuery(dbcore.FieldQuery):
         self.file_path = util.bytestring_path(util.normpath(pattern))
         # As a directory (prefix).
         self.dir_path = util.bytestring_path(os.path.join(self.file_path, b''))
+
+    @staticmethod
+    def is_filesystem_case_sensitive():
+        library_path = beets.config['directory'].get()
+        if os.path.exists(library_path):
+            # Check if the path to the library exists in lower and upper case
+            return not (os.path.exists(library_path.lower()) and
+                        os.path.exists(library_path.upper()))
+        # By default, the case sensitivity depends on the platform.
+        return platform.system() != 'Windows'
 
     @classmethod
     def is_path_query(cls, query_part):

--- a/beets/library.py
+++ b/beets/library.py
@@ -24,7 +24,6 @@ import unicodedata
 import time
 import re
 from unidecode import unidecode
-import platform
 
 from beets import logging
 from beets.mediafile import MediaFile, MutagenError, UnreadableFileError
@@ -62,7 +61,8 @@ class PathQuery(dbcore.FieldQuery):
         super(PathQuery, self).__init__(field, pattern, fast)
 
         if case_sensitive is None:
-            case_sensitive = self.is_filesystem_case_sensitive()
+            case_sensitive = beets.util.is_filesystem_case_sensitive(
+                beets.config['directory'].get())
         self.case_sensitive = case_sensitive
 
         # Use a normalized-case pattern for case-insensitive matches.
@@ -73,16 +73,6 @@ class PathQuery(dbcore.FieldQuery):
         self.file_path = util.bytestring_path(util.normpath(pattern))
         # As a directory (prefix).
         self.dir_path = util.bytestring_path(os.path.join(self.file_path, b''))
-
-    @staticmethod
-    def is_filesystem_case_sensitive():
-        library_path = beets.config['directory'].get()
-        if os.path.exists(library_path):
-            # Check if the path to the library exists in lower and upper case
-            return not (os.path.exists(library_path.lower()) and
-                        os.path.exists(library_path.upper()))
-        # By default, the case sensitivity depends on the platform.
-        return platform.system() != 'Windows'
 
     @classmethod
     def is_path_query(cls, query_part):

--- a/beets/library.py
+++ b/beets/library.py
@@ -60,6 +60,8 @@ class PathQuery(dbcore.FieldQuery):
         """
         super(PathQuery, self).__init__(field, pattern, fast)
 
+        # By default, the case sensitivity depends on the filesystem
+        # the library is located on.
         if case_sensitive is None:
             case_sensitive = beets.util.is_filesystem_case_sensitive(
                 beets.config['directory'].get())

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -759,3 +759,41 @@ def interactive_open(target, command=None):
 
     command.append(target)
     return os.execlp(*command)
+
+
+def is_filesystem_case_sensitive(path):
+    if os.path.exists(path):
+        # Check if the path to the library exists in lower and upper case
+        if os.path.exists(path.lower()) and \
+           os.path.exists(path.upper()):
+            # All the paths may exist on the file system. Check if they
+            # refer to different files
+            if platform.system() != 'Windows':
+                # os.path.samefile is only available on Unix systems for
+                # python < 3.0
+                return not os.path.samefile(path.lower(),
+                                            path.upper())
+            # On windows we create a file with a lower case name
+            # and try to find the file using an upper case name.
+            base_file_name = 'beetsCaseSensitivityCheck'
+            lower = os.path.join(path, base_file_name.lower())
+            upper = os.path.join(path, base_file_name.upper())
+            # Check if one of the files (upper and lower case) do exist
+            # already
+            i = 0
+            while os.path.exists(lower) or os.path.exists(upper):
+                file_name = '{0}{1}'.format(base_file_name, i)
+                lower = os.path.join(path, file_name.lower())
+                upper = os.path.join(path, file_name.upper())
+            # Create the file using a lower case name
+            with open(lower, 'w'):
+                pass
+            # Check if the file can be found using the upper cas name
+            case_sensitive = not os.path.exists(upper)
+            # Remove the temporary file
+            os.remove(lower)
+            return case_sensitive
+        else:
+            return True
+    # By default, the case sensitivity depends on the platform.
+    return platform.system() != 'Windows'

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -762,6 +762,13 @@ def interactive_open(target, command=None):
 
 
 def is_filesystem_case_sensitive(path):
+    """Checks if the filesystem at the given path is case sensitive.
+    If the path does not exist, a case sensitive file system is
+    assumed if the system is not windows.
+
+    :param path: The path to check for case sensitivity.
+    :return: True if the file system is case sensitive, False else.
+    """
     if os.path.exists(path):
         # Check if the path to the library exists in lower and upper case
         if os.path.exists(path.lower()) and \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Fixes:
   option.
 * The :ref:`list-cmd` command's help output now has a small query and format
   string example. Thanks to :user:`pkess`. :bug:`1582`
+* The check whether the file system is case sensitive or not could lead to
+  wrong results. It is much more robust now.
 
 
 1.3.14 (August 2, 2015)

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -202,8 +202,8 @@ Note that this only matches items that are *already in your library*, so a path
 query won't necessarily find *all* the audio files in a directory---just the
 ones you've already added to your beets library.
 
-Path queries are case-sensitive on most platforms but case-insensitive on
-Windows.
+Path queries are case-sensitive if the file system the library is located on
+is case-sensitive, case-insensitive otherwise.
 
 .. _query-sort:
 


### PR DESCRIPTION
This is a little improvement to find out if the file system is case sensitive or not. Until now, beets uses the operating system to determine this: On Windows, beets detected a case insensitive file system, on all other systems it is detected as case sensitive. At least this might be wrong: MacOS' HFS+ might be case sensitive or not. And what if the library is located on a FAT formated file system under Linux?

(In fact, the wrong detection was the reason I opened #1496.)