### PR TITLE
Fix #1303: process `DateItemField` tags in YMD order

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -1461,6 +1461,28 @@ class MediaFile(object):
                 yield property.decode('utf8')
 
     @classmethod
+    def field_sort_name(cls, name):
+        """Get field name for sorting purposes. Fields names are kept
+        unchanged, unless they are instances of :class:`DateItemField`,
+        in which case `year`, `month`, and `day` are replaced by `date0`,
+        `date1`, and `date2`, respectively.
+        """
+        if isinstance(cls.__dict__[name], DateItemField):
+            name = re.sub('year',  'date0', name)
+            name = re.sub('month', 'date1', name)
+            name = re.sub('day',   'date2', name)
+        return name
+
+    @classmethod
+    def sorted_fields(cls):
+        """Get the names of all writable metadata fields sorted by
+        lexicographic order (except for instances of :class:`DateItemField`,
+        which are sorted in year-month-day order).
+        """
+        for property in sorted(cls.fields(), key = cls.field_sort_name):
+            yield property
+
+    @classmethod
     def readable_fields(cls):
         """Get all metadata fields: the writable ones from
         :meth:`fields` and also other audio properties.
@@ -1496,7 +1518,7 @@ class MediaFile(object):
         the `MediaFile`. If a key has the value `None`, the
         corresponding property is deleted from the `MediaFile`.
         """
-        for field in self.fields():
+        for field in self.sorted_fields():
             if field in dict:
                 if dict[field] is None:
                     delattr(self, field)

--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -1479,7 +1479,7 @@ class MediaFile(object):
         lexicographic order (except for instances of :class:`DateItemField`,
         which are sorted in year-month-day order).
         """
-        for property in sorted(cls.fields(), key = cls.field_sort_name):
+        for property in sorted(cls.fields(), key=cls.field_sort_name):
             yield property
 
     @classmethod


### PR DESCRIPTION
Hi,

This should fix bug #1303. Basically, this patch sorts the name of all metadata tags in (a somewhat tweaked) lexicographic order when they are processed by the `MediaFile.update()` method.

Only instances of `DateItemField` get sorted in the year < month < day order, so that updates to the corresponding `DateField` object are done in the proper order. It does so by replacing the substrings `year`, `month`, and `day` by `date0`, `date1`, and `date2`, respectively, in the field name of `DateItemField` objects, so that this new string can be used as a key for the sorting algorithm.

There are several other ways to do that, but I think that's the more robust. I'm of course open to discussion. :smiley:

Cheers,
Jérémie.