### PR TITLE
Add `remove_art_file` configuration property to EmbedArt plugin

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -37,6 +37,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             'auto': True,
             'compare_threshold': 0,
             'ifempty': False,
+            'remove_art_file': False
         })
 
         if self.config['maxwidth'].get(int) and not ArtResizer.shared.local:
@@ -62,6 +63,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         maxwidth = self.config['maxwidth'].get(int)
         compare_threshold = self.config['compare_threshold'].get(int)
         ifempty = self.config['ifempty'].get(bool)
+        remove_art_file = self.config['remove_art_file'].get(bool)
 
         def embed_func(lib, opts, args):
             if opts.file:
@@ -77,6 +79,11 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 for album in lib.albums(decargs(args)):
                     art.embed_album(self._log, album, maxwidth, False,
                                     compare_threshold, ifempty)
+
+                    if remove_art_file and album.artpath is not None:
+                        if os.path.isfile(album.artpath):
+                            self._log.debug(u'Removing album art file for {0}', album)
+                            os.remove(album.artpath)
 
         embed_cmd.func = embed_func
 

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -82,7 +82,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
                     if remove_art_file and album.artpath is not None:
                         if os.path.isfile(album.artpath):
-                            self._log.debug(u'Removing album art file for {0}', album)
+                            self._log.debug(u'Removing album art file '
+                                            u'for {0}', album)
                             os.remove(album.artpath)
 
         embed_cmd.func = embed_func

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -18,7 +18,6 @@ from __future__ import (division, absolute_import, print_function,
 
 import os.path
 
-from beets import plugins
 from beets.plugins import BeetsPlugin
 from beets import ui
 from beets.ui import decargs

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -18,6 +18,7 @@ from __future__ import (division, absolute_import, print_function,
 
 import os.path
 
+from beets import plugins
 from beets.plugins import BeetsPlugin
 from beets import ui
 from beets.ui import decargs
@@ -85,6 +86,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                             self._log.debug(u'Removing album art file '
                                             u'for {0}', album)
                             os.remove(album.artpath)
+                            album.artpath = None
+                            album.store()
 
         embed_cmd.func = embed_func
 

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -59,7 +59,10 @@ file. The available options are:
   caveats about image resizing.
   Default: 0 (disabled).
 - **remove_art_file**: Automatically remove the album art file for the album
-  after it has been embedded.
+  after it has been embedded. This option is best used alongside the
+  :doc:`FetchArt </plugins/fetchart>` plugin to download art with the purpose of
+  directly embedding it into the file's metadata without an "intermediate"
+  album art file.
   Default: ``no``.
 
 Note: ``compare_threshold`` option requires `ImageMagick`_, and ``maxwidth``

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -58,6 +58,9 @@ file. The available options are:
   the aspect ratio is preserved. See also :ref:`image-resizing` for further
   caveats about image resizing.
   Default: 0 (disabled).
+- **remove_art_file**: Automatically remove the album art file for the album
+  after it has been embedded.
+  Default: ``no``.
 
 Note: ``compare_threshold`` option requires `ImageMagick`_, and ``maxwidth``
 requires either `ImageMagick`_ or `PIL`_.


### PR DESCRIPTION
Adds a configuration property for automatically removing album art files after embedding them.

```yaml
embedart:
  remove_art_file: yes|no
```
