### PR TITLE
Add `library_name` configuration property to PlexUpdate plugin (fixes #1572)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ The new features:
   :bug:`1591` :bug:`733`
 * :doc:`/plugins/play`: You can now configure the number of tracks that
   trigger a "lots of music" warning. :bug:`1577`
+* :doc:`/plugins/plexupdate`: A new ``library_name`` option allows you to select
+  which Plex library to update. :bug:`1572` :bug:`1595`
 
 Fixes:
 

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -39,3 +39,5 @@ The available options under the ``plex:`` section are:
   Default: 32400.
 - **token**: The Plex Home token.
   Default: Empty.
+- **library_name**: The name of the Plex library to update.
+  Default: ``Music``

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -88,7 +88,8 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         self.assertEqual(get_music_section(
             self.config['plex']['host'],
             self.config['plex']['port'],
-            self.config['plex']['token']), '2')
+            self.config['plex']['token'],
+            self.config['plex']['library_name'].get()), '2')
 
     @responses.activate
     def test_update_plex(self):
@@ -100,7 +101,8 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         self.assertEqual(update_plex(
             self.config['plex']['host'],
             self.config['plex']['port'],
-            self.config['plex']['token']).status_code, 200)
+            self.config['plex']['token'],
+            self.config['plex']['library_name'].get()).status_code, 200)
 
 
 def suite():


### PR DESCRIPTION
Adds a configuration property to allow the use of libraries that are not named `Music`. This fixes #1572.

```yaml
plexupdate:
  library_name: Music (new)
```