### PR TITLE
Bugfix for cas insensitive searches for a file path

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -66,10 +66,6 @@ class PathQuery(dbcore.FieldQuery):
             case_sensitive = platform.system() != 'Windows'
         self.case_sensitive = case_sensitive
 
-        # Use a normalized-case pattern for case-insensitive matches.
-        if not case_sensitive:
-            pattern = pattern.lower()
-
         # Match the path as a single file.
         self.file_path = util.bytestring_path(util.normpath(pattern))
         # As a directory (prefix).
@@ -102,8 +98,8 @@ class PathQuery(dbcore.FieldQuery):
         escape = lambda m: self.escape_char + m.group(0)
         dir_pattern = self.escape_re.sub(escape, self.dir_path)
         dir_blob = buffer(dir_pattern + b'%')
-        return '({0} = ?) || ({0} LIKE ? ESCAPE ?)'.format(self.field), \
-               (file_blob, dir_blob, self.escape_char)
+        return '(lower({0}) = lower(?)) || ({0} LIKE ? ESCAPE ?)'.format(
+            self.field), (file_blob, dir_blob, self.escape_char)
 
 
 # Library-specific field types.

--- a/beets/library.py
+++ b/beets/library.py
@@ -66,6 +66,10 @@ class PathQuery(dbcore.FieldQuery):
             case_sensitive = platform.system() != 'Windows'
         self.case_sensitive = case_sensitive
 
+        # Use a normalized-case pattern for case-insensitive matches.
+        if not case_sensitive:
+            pattern = pattern.lower()
+
         # Match the path as a single file.
         self.file_path = util.bytestring_path(util.normpath(pattern))
         # As a directory (prefix).
@@ -88,9 +92,8 @@ class PathQuery(dbcore.FieldQuery):
         return (path == self.file_path) or path.startswith(self.dir_path)
 
     def col_clause(self):
-        file_blob = buffer(self.file_path)
-
         if self.case_sensitive:
+            file_blob = buffer(self.file_path)
             dir_blob = buffer(self.dir_path)
             return '({0} = ?) || (substr({0}, 1, ?) = ?)'.format(self.field), \
                    (file_blob, len(dir_blob), dir_blob)
@@ -98,8 +101,11 @@ class PathQuery(dbcore.FieldQuery):
         escape = lambda m: self.escape_char + m.group(0)
         dir_pattern = self.escape_re.sub(escape, self.dir_path)
         dir_blob = buffer(dir_pattern + b'%')
-        return '(lower({0}) = lower(?)) || ({0} LIKE ? ESCAPE ?)'.format(
-            self.field), (file_blob, dir_blob, self.escape_char)
+        file_pattern = self.escape_re.sub(escape, self.file_path)
+        file_blob = buffer(file_pattern + b'%')
+        return '({0} LIKE ? ESCAPE ?) || ({0} LIKE ? ESCAPE ?)'.format(
+            self.field), (file_blob, self.escape_char, dir_blob,
+                          self.escape_char)
 
 
 # Library-specific field types.

--- a/beets/library.py
+++ b/beets/library.py
@@ -102,7 +102,7 @@ class PathQuery(dbcore.FieldQuery):
         dir_pattern = self.escape_re.sub(escape, self.dir_path)
         dir_blob = buffer(dir_pattern + b'%')
         file_pattern = self.escape_re.sub(escape, self.file_path)
-        file_blob = buffer(file_pattern + b'%')
+        file_blob = buffer(file_pattern)
         return '({0} LIKE ? ESCAPE ?) || ({0} LIKE ? ESCAPE ?)'.format(
             self.field), (file_blob, self.escape_char, dir_blob,
                           self.escape_char)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,8 @@ Fixes:
   written to files. Thanks to :user:`jdetrey`. :bug:`1303` :bug:`1589`
 * :doc:`/plugins/replaygain`: Avoid a crash when the PyAudioTools backend
   encounters an error. :bug:`1592`
+* Case insensitive searches might have returned nothing because of a wrong
+  SQL query.
 
 
 1.3.14 (August 2, 2015)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,8 +45,8 @@ Fixes:
   written to files. Thanks to :user:`jdetrey`. :bug:`1303` :bug:`1589`
 * :doc:`/plugins/replaygain`: Avoid a crash when the PyAudioTools backend
   encounters an error. :bug:`1592`
-* Case insensitive searches might have returned nothing because of a wrong
-  SQL query.
+* Case-insensitive path queries might have returned nothing because of a
+  wrong SQL query.
 
 
 1.3.14 (August 2, 2015)


### PR DESCRIPTION
This will fix #1587 by using the case-lowering of the database instead of Python and SQLite.