### PR TITLE
Make command filtering in zsh completion more robust.

### DIFF
--- a/extra/_beet
+++ b/extra/_beet
@@ -154,7 +154,7 @@ function _beet_subcmd_options()
 # Now build the arguments to _regex_arguments for each subcommand.
 local -a options regex_words_subcmds regex_words_help
 local subcmd cmddesc
-for i in ${${(f)"$(beet help | awk 'f;/Commands:/{f=1}')"[@]}[@]}
+for i in ${${(f)"$(beet help | awk 'f;/Commands:/{f=1}' | grep '^  \w.*')"[@]}[@]}
 do
     subcmd="${i[(w)1]}"
     cmddesc="${${${${${i[(w)2,-1]##\(*\) #}//:/-}//\[/(}//\]/)}//\'/}"


### PR DESCRIPTION
- Filter out any lines that don't resemble a command in the help text.

- Fixes #1525.