### PR TITLE
beets is available as a package for openbsd releases since ~1 year now.

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -34,8 +34,7 @@ dropped, and Python 3.x is not yet supported.)
 
 * On **FreeBSD**, there's a `beets port`_ at ``audio/beets``.
 
-* On **OpenBSD-current**, beets is available in ports (at ``audio/beets``) and
-  as a package, which can be installed with ``pkg_add beets``.
+* On **OpenBSD**, beets can be installed with ``pkg_add beets``.
 
 * For **Slackware**, there's a `SlackBuild`_ available.
 


### PR DESCRIPTION
Hi sampsyo,

beets is available as a package on openbsd since nearly 3 releases now, so we can safely strip the -current-tag. Here's my old pull request which kind of announces this pr ;) https://github.com/sampsyo/beets/pull/794

Thanks for this great program. It's a joy to use.