### PR TITLE
Add new ``include`` config option.

### DIFF
--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import os
+
 import beets.library
 from beets.util import confit
 
@@ -23,3 +25,13 @@ __author__ = 'Adrian Sampson <adrian@radbox.org>'
 Library = beets.library.Library
 
 config = confit.LazyConfig('beets', __name__)
+
+try:
+    included_filenames = config['include'].get(list)
+except confit.NotFoundError:
+    included_filenames = []
+
+for filename in included_filenames:
+    filename = os.path.join(config.config_dir(), filename)
+    if os.path.isfile(filename):
+        config.set_file(filename)

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -779,16 +779,6 @@ class Configuration(RootView):
         if os.path.isfile(filename):
             self.add(ConfigSource(load_yaml(filename) or {}, filename))
 
-        try:
-            included_filenames = self['include'].get(list)
-        except NotFoundError:
-            included_filenames = []
-
-        for filename in included_filenames:
-            filename = os.path.join(self.config_dir(), filename)
-            if os.path.isfile(filename):
-                self.add(ConfigSource(load_yaml(filename) or {}, filename))
-
     def _add_default_source(self):
         """Add the package's default configuration settings. This looks
         for a YAML file located inside the package for the module

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -779,6 +779,16 @@ class Configuration(RootView):
         if os.path.isfile(filename):
             self.add(ConfigSource(load_yaml(filename) or {}, filename))
 
+        try:
+            included_filenames = self['include'].get(list)
+        except NotFoundError:
+            included_filenames = []
+
+        for filename in included_filenames:
+            filename = os.path.join(self.config_dir(), filename)
+            if os.path.isfile(filename):
+                self.add(ConfigSource(load_yaml(filename) or {}, filename))
+
     def _add_default_source(self):
         """Add the package's default configuration settings. This looks
         for a YAML file located inside the package for the module

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ The new features:
   trigger a "lots of music" warning. :bug:`1577`
 * :doc:`/plugins/plexupdate`: A new ``library_name`` option allows you to select
   which Plex library to update. :bug:`1572` :bug:`1595`
+* Add new `include` config option to allow including external config files.
 
 Fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -64,6 +64,12 @@ plugins
 A space-separated list of plugin module names to load. See
 :ref:`using-plugins`.
 
+include
+~~~~~~~
+
+A space-separated list of extra configuration files to include.
+Filenames are relative to the directory containing ``config.yaml``.
+
 pluginpath
 ~~~~~~~~~~
 


### PR DESCRIPTION
This new option allows users to provide a list of external config files which will be evaluated when beets starts.

This is useful for keeping private settings (e.g. API keys) out of the main configuration file.

There are no tests for the new behavior because I couldn't think of a simple way to test it but I've been running with this for about a month so far with no issues.