### PR TITLE
Remove yaml keys without sublists

### DIFF
--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -494,8 +494,8 @@
     - lyrical hip hop
     - merenrap
     - midwest hip hop:
-        - chicago hip hop:
-        - detroit hip hop:
+        - chicago hip hop
+        - detroit hip hop
         - horrorcore
         - st. louis hip hop
         - twin cities hip hop
@@ -652,7 +652,7 @@
     - glam rock
     - hard rock
     - heavy metal:
-        - alternative metal:
+        - alternative metal
         - black metal:
             - viking metal
         - christian metal


### PR DESCRIPTION
Just cleaning up this yaml a bit. I tried to parse it with a Ruby YAML parser and it choked on these keys.