### PR TITLE
Add Genius as a lyric source

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ The new features:
 * :doc:`/plugins/plexupdate`: A new ``library_name`` option allows you to select
   which Plex library to update. :bug:`1572` :bug:`1595`
 * Add new `include` config option to allow including external config files.
+* :doc:`/plugins/lyrics`: Genius.com is now a source for lyrics.
 
 Fixes:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -3,11 +3,12 @@ Lyrics Plugin
 
 The ``lyrics`` plugin fetches and stores song lyrics from databases on the Web.
 Namely, the current version of the plugin uses `Lyric Wiki`_, `Lyrics.com`_,
-`Musixmatch`_, and, optionally, the Google custom search API.
+`Musixmatch`_, `Genius.com`_, and, optionally, the Google custom search API.
 
 .. _Lyric Wiki: http://lyrics.wikia.com/
 .. _Lyrics.com: http://www.lyrics.com/
 .. _Musixmatch: https://www.musixmatch.com/
+.. _Genius.com: http://genius.com/
 
 
 Fetch Lyrics During Import


### PR DESCRIPTION
Makes use of the Genius API and genius-api.com, a separate resource that
provides readable lyrics.

Fixes #1626.

This is my first contribution to beets so please let me know if anything is amiss.  I'd like to wrap some testing around this but I'm not particularly familiar with python testing frameworks, so that may take a little while longer.

Requires a new config option ```genius_API_key```, and ```requests[security]``` to quell InsecureResponseWarnings.