### PR TITLE
Fix example of Types plugin documentation

### DIFF
--- a/docs/plugins/types.rst
+++ b/docs/plugins/types.rst
@@ -23,4 +23,4 @@ queries <numericquery>` to filter them.::
     beet ls rating:4..5
 
     beet modify --album "My favorite album" rating=5
-    beet modify --album rating:4..5
+    beet ls --album rating:4..5


### PR DESCRIPTION
There's a little mistake in the Types plugin documentation: on the album example, the querying is done with `modify` instead of `ls`.