### PR TITLE
Various fixes related to album art (#314, #1126, #1264)

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -671,8 +671,8 @@ class ImportTask(BaseImportTask):
         self.old_paths = [item.path for item in items]
 
         # Keep track of paths of all original album art for the same reason.
-        self.old_art_paths = set(filter(bool,
-            (album.artpath for album in self.replaced_albums.values())))
+        self.old_art_paths = set(filter(
+            bool, (album.artpath for album in self.replaced_albums.values())))
 
         for item in items:
             if move or copy or link:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -567,8 +567,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     self._log.debug('using remote image {}', out)
                     break
 
-        if self.maxwidth and out and check == CANDIDATE_DOWNSCALE:
-                out = ArtResizer.shared.resize(self.maxwidth, out)
+        if check == CANDIDATE_DOWNSCALE:
+            out = ArtResizer.shared.resize(self.maxwidth, out)
 
         return out
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -45,6 +45,7 @@ CANDIDATE_BAD = 0
 CANDIDATE_EXACT = 1
 CANDIDATE_DOWNSCALE = 2
 
+
 def _logged_get(log, *args, **kwargs):
     """Like `requests.get`, but logs the effective URL to the specified
     `log` at the `DEBUG` level.
@@ -525,7 +526,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             return CANDIDATE_EXACT
 
         if size[0] >= self.minwidth and (
-            not self.enforce_ratio or size[0] == size[1]):
+                not self.enforce_ratio or size[0] == size[1]):
             if size[0] > self.maxwidth:
                 return CANDIDATE_DOWNSCALE
             return CANDIDATE_EXACT
@@ -567,7 +568,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     self._log.debug('using remote image {}', out)
                     break
 
-        if check == CANDIDATE_DOWNSCALE:
+        if self.maxwidth and out and check == CANDIDATE_DOWNSCALE:
             out = ArtResizer.shared.resize(self.maxwidth, out)
 
         return out

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -567,7 +567,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         fetchart CLI command.
         """
         for album in albums:
-            if album.artpath and not force:
+            if album.artpath and not force and os.path.isfile(album.artpath):
                 message = ui.colorize('text_highlight_minor', 'has album art')
             else:
                 # In ordinary invocations, look for images on the

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -41,6 +41,9 @@ IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg']
 CONTENT_TYPES = ('image/jpeg', 'image/png')
 DOWNLOAD_EXTENSION = '.jpg'
 
+CANDIDATE_BAD = 0
+CANDIDATE_EXACT = 1
+CANDIDATE_DOWNSCALE = 2
 
 def _logged_get(log, *args, **kwargs):
     """Like `requests.get`, but logs the effective URL to the specified
@@ -506,10 +509,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     def _is_valid_image_candidate(self, candidate):
         if not candidate:
-            return False
+            return CANDIDATE_BAD
 
         if not (self.enforce_ratio or self.minwidth):
-            return True
+            return CANDIDATE_EXACT
 
         # get_size returns None if no local imaging backend is available
         size = ArtResizer.shared.get_size(candidate)
@@ -519,10 +522,14 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                               u'documentation for dependencies. '
                               u'The configuration options `minwidth` and '
                               u'`enforce_ratio` may be violated.')
-            return True
+            return CANDIDATE_EXACT
 
-        return size and size[0] >= self.minwidth and \
-            (not self.enforce_ratio or size[0] == size[1])
+        if size[0] >= self.minwidth and (
+            not self.enforce_ratio or size[0] == size[1]):
+            if size[0] > self.maxwidth:
+                return CANDIDATE_DOWNSCALE
+            return CANDIDATE_EXACT
+        return CANDIDATE_BAD
 
     def art_for_album(self, album, paths, local_only=False):
         """Given an Album object, returns a path to downloaded art for the
@@ -532,6 +539,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         are made.
         """
         out = None
+        check = None
 
         # Local art.
         cover_names = self.config['cover_names'].as_str_seq()
@@ -540,7 +548,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         if paths:
             for path in paths:
                 candidate = self.fs_source.get(path, cover_names, cautious)
-                if self._is_valid_image_candidate(candidate):
+                check = self._is_valid_image_candidate(candidate)
+                if check:
                     out = candidate
                     self._log.debug('found local image {}', out)
                     break
@@ -552,12 +561,13 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 if self.maxwidth:
                     url = ArtResizer.shared.proxy_url(self.maxwidth, url)
                 candidate = self._fetch_image(url)
-                if self._is_valid_image_candidate(candidate):
+                check = self._is_valid_image_candidate(candidate)
+                if check:
                     out = candidate
                     self._log.debug('using remote image {}', out)
                     break
 
-        if self.maxwidth and out:
+        if check == CANDIDATE_DOWNSCALE:
             out = ArtResizer.shared.resize(self.maxwidth, out)
 
         return out

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -567,8 +567,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     self._log.debug('using remote image {}', out)
                     break
 
-        if check == CANDIDATE_DOWNSCALE:
-            out = ArtResizer.shared.resize(self.maxwidth, out)
+        if self.maxwidth and out and check == CANDIDATE_DOWNSCALE:
+                out = ArtResizer.shared.resize(self.maxwidth, out)
 
         return out
 


### PR DESCRIPTION
This is my attempt at ironing out a few bugs related to album art, targeting the `fetchart` plugin and the importer itself.

##### #314 Re-import should move album art
With a few changes to `importer.py`, the re-import workflow deletes orphaned album art by keeping track of which files aren't reused by `fetchart` during the import process.

##### #1126 Tracks don't have cover, but beet says "...has album art"
This can be reproduced by simply deleting `cover.jpg` (or equivalent album art file) and then running `beet fetchart`. With this change, when invoking `fetchart` as a command, it will also check if the actual file given by `artpath`  exists in that directory.

##### #1264 Re-importing with fetchart creates two album art files
I believe this is caused by the fact that if a local `cover.jpg` exists, the `fetchart` plugin would then "discover" this during the import and reuse it. Furthermore, if the `maxwidth` setting is used, `fetchart` will always resize it, creating `cover.1.jpg` in the process. I've rewritten it slightly so that it will only resize if the image is actually wider than `maxwidth`, making `import -L` an idempotent operation.

Your thoughts, please?