### PR TITLE
Fix #314: Delete old album art during re-import

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -547,23 +547,6 @@ class ImportTask(BaseImportTask):
 
         items = self.imported_items()
 
-        # If any original album art files were reused, leave them untouched.
-        for item in items:
-            album = item.get_album()
-            if album:
-                self.old_art_paths.discard(album.artpath)
-
-        # Delete remaining original album art files.
-        for old_art_path in self.old_art_paths:
-            log.debug('Deleting orphaned album art: {0}', old_art_path)
-            util.remove(syspath(old_art_path), True)
-            # XXX: Ideally the directory would get pruned with self.prune()
-            # below, but when calling `beet import -L`, self.toppath is set
-            # to None, making self.prune() a no-op; hence this workaround of
-            # calling util.prune_dirs() directly.
-            util.prune_dirs(os.path.dirname(old_art_path),
-                            clutter=config['clutter'].as_str_seq())
-
         # When copying and deleting originals, delete old files.
         if copy and delete:
             new_paths = [os.path.realpath(item.path) for item in items]
@@ -669,11 +652,6 @@ class ImportTask(BaseImportTask):
         # Save the original paths of all items for deletion and pruning
         # in the next step (finalization).
         self.old_paths = [item.path for item in items]
-
-        # Keep track of paths of all original album art for the same reason.
-        self.old_art_paths = set(filter(
-            bool, (album.artpath for album in self.replaced_albums.values())))
-
         for item in items:
             if move or copy or link:
                 # In copy and link modes, treat re-imports specially:

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -671,8 +671,8 @@ class ImportTask(BaseImportTask):
         self.old_paths = [item.path for item in items]
 
         # Keep track of paths of all original album art for the same reason.
-        self.old_art_paths = set(filter(bool,
-            (album.artpath for album in self.replaced_albums.values())))
+        self.old_art_paths = set(filter(
+            bool, (album.artpath for album in self.replaced_albums.values())))
 
         for item in items:
             if move or copy or link:

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -718,6 +718,7 @@ class ImportTask(BaseImportTask):
             if replaced_album:
                 self.album.added = replaced_album.added
                 self.album.update(replaced_album._values_flex)
+                self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
                     u'Reimported album: added {0}, flexible '

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -430,6 +430,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
     def fetch_art(self, session, task):
         """Find art for the album being imported."""
         if task.is_album:  # Only fetch art for full albums.
+            if task.album.artpath and os.path.isfile(task.album.artpath):
+                # Album already has art (probably a re-import); skip it.
+                return
             if task.choice_flag == importer.action.ASIS:
                 # For as-is imports, don't search Web sources for art.
                 local = True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,10 @@ Fixes:
   when there were not. :bug:`1652`
 * :doc:`plugins/lastgenre`: Clean up the reggae related genres somewhat.
   Thanks to :user:`Freso`. :bug:`1661`
+* The importer now correctly moves album art files when re-importing.
+  :bug:`314`
+* :doc:`/plugins/fetchart`: In auto mode, skips albums that already have
+  art attached to them so as not to interfere with re-imports. :bug:`314`
 
 
 1.3.15 (October 17, 2015)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1594,15 +1594,18 @@ class ReimportTest(unittest.TestCase, ImportHelper):
 
     def test_reimported_item_preserves_art(self):
         self._setup_session()
-        artpath = os.path.join(_common.RSRC, 'abbey.jpg')
+        art_source = os.path.join(_common.RSRC, 'abbey.jpg')
         replaced_album = self._album()
-        replaced_album.set_art(artpath)
+        replaced_album.set_art(art_source)
         replaced_album.store()
+        old_artpath = replaced_album.artpath
         self.importer.run()
         new_album = self._album()
-        new_artpath = new_album.art_destination(artpath)
+        new_artpath = new_album.art_destination(art_source)
         self.assertEqual(new_album.artpath, new_artpath)
         self.assertTrue(os.path.exists(new_artpath))
+        if new_artpath != old_artpath:
+            self.assertFalse(os.path.exists(old_artpath))
 
 
 class ImportPretendTest(_common.TestCase, ImportHelper):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1592,6 +1592,18 @@ class ReimportTest(unittest.TestCase, ImportHelper):
         self.importer.run()
         self.assertEqual(self._item().added, 4747.0)
 
+    def test_reimported_item_preserves_art(self):
+        self._setup_session()
+        artpath = os.path.join(_common.RSRC, 'abbey.jpg')
+        replaced_album = self._album()
+        replaced_album.set_art(artpath)
+        replaced_album.store()
+        self.importer.run()
+        new_album = self._album()
+        new_artpath = new_album.art_destination(artpath)
+        self.assertEqual(new_album.artpath, new_artpath)
+        self.assertTrue(os.path.exists(new_artpath))
+
 
 class ImportPretendTest(_common.TestCase, ImportHelper):
     """ Test the pretend commandline option


### PR DESCRIPTION
Part of #1679 by @reiv.

> With a few changes to `importer.py`, the re-import workflow deletes orphaned album art by keeping track of which files aren't reused by `fetchart` during the import process.