### PR TITLE
Fix #1126: Check if album art file actually exists

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -567,7 +567,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         fetchart CLI command.
         """
         for album in albums:
-            if album.artpath and not force:
+            if album.artpath and not force and os.path.isfile(album.artpath):
                 message = ui.colorize('text_highlight_minor', 'has album art')
             else:
                 # In ordinary invocations, look for images on the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,9 @@ Fixes:
   when there were not. :bug:`1652`
 * :doc:`plugins/lastgenre`: Clean up the reggae related genres somewhat.
   Thanks to :user:`Freso`. :bug:`1661`
+* :doc:`plugins/fetchart`: Fix a bug where a database reference to a
+  non-existent album art file would prevent the command from fetching new art.
+  :bug:`1126`
 
 
 1.3.15 (October 17, 2015)

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -30,6 +30,7 @@ from beets import library
 from beets import importer
 from beets import config
 from beets import logging
+from beets import util
 from beets.util.artresizer import ArtResizer, WEBPROXY
 
 
@@ -356,6 +357,18 @@ class ArtImporterTest(UseThePlugin):
         shutil.copyfile(self.art_file, artdest)
         self.afa_response = artdest
         self._fetch_art(True)
+
+    def test_fetch_art_if_imported_file_deleted(self):
+        # See #1126. Test the following scenario:
+        #   - Album art imported, `album.artpath` set.
+        #   - Imported album art file subsequently deleted (by user or other
+        #     program).
+        # `fetchart` should import album art again instead of printing the
+        # message "<album> has album art".
+        self._fetch_art(True)
+        util.remove(self.album.artpath)
+        self.plugin.batch_fetch_art(self.lib, self.lib.albums(), force=False)
+        self.assertExists(self.album.artpath)
 
 
 class ArtForAlbumTest(UseThePlugin):


### PR DESCRIPTION
Part of #1679 by @reiv.

> This can be reproduced by simply deleting `cover.jpg` (or equivalent album art file) and then running `beet fetchart`. With this change, when invoking `fetchart` as a command, it will also check if the actual file given by `artpath`  exists in that directory.