### PR TITLE
Discogs: change album artist to musicbrainz naming

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -226,7 +226,7 @@ class DiscogsPlugin(BeetsPlugin):
             result.data['formats'][0].get('descriptions', [])) or None
         va = result.data['artists'][0]['name'].lower() == 'various'
         if va:
-           artist = self.config['va_name'].get()
+            artist = self.config['va_name'].get()
         year = result.data['year']
         label = result.data['labels'][0]['name']
         mediums = len(set(t.medium for t in tracks))

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -57,6 +57,7 @@ class DiscogsPlugin(BeetsPlugin):
             'apisecret': 'plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy',
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
+            'change_va': False,
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
@@ -224,6 +225,8 @@ class DiscogsPlugin(BeetsPlugin):
         albumtype = ', '.join(
             result.data['formats'][0].get('descriptions', [])) or None
         va = result.data['artists'][0]['name'].lower() == 'various'
+        if va and self.config['change_va']:
+           artist = 'Various Artists'
         year = result.data['year']
         label = result.data['labels'][0]['name']
         mediums = len(set(t.medium for t in tracks))

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -57,7 +57,7 @@ class DiscogsPlugin(BeetsPlugin):
             'apisecret': 'plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy',
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
-            'change_va': False,
+            'va_name': 'Various Artists',
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
@@ -225,8 +225,8 @@ class DiscogsPlugin(BeetsPlugin):
         albumtype = ', '.join(
             result.data['formats'][0].get('descriptions', [])) or None
         va = result.data['artists'][0]['name'].lower() == 'various'
-        if va and self.config['change_va']:
-           artist = 'Various Artists'
+        if va:
+           artist = self.config['va_name'].get()
         year = result.data['year']
         label = result.data['labels'][0]['name']
         mediums = len(set(t.medium for t in tracks))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Fixes:
   (as well as with the explicit command). :bug:`1662` :bug:`1675`
 * :doc:`/plugins/discogs`: New config option (va_name) to change the default
   album artist name if album is V.A. The default is changed to 'Various Artists'
-  to be the same as for MusicBrainz.
+  to be the same as MusicBrainz.
 
 
 1.3.15 (October 17, 2015)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,9 +24,9 @@ Fixes:
 * :doc:`/plugins/thumbnails`: Fix a crash with Unicode paths. :bug:`1686`
 * :doc:`/plugins/embedart`: The ``remove_art_file`` option now works on import
   (as well as with the explicit command). :bug:`1662` :bug:`1675`
-* :doc:`/plugins/discogs`: New config option to change the default album 
-  artist name if album is V.A. The default is changed to 'Various Artists' to
-  be the same as for MusicBrainz.
+* :doc:`/plugins/discogs`: New config option (va_name) to change the default
+  album artist name if album is V.A. The default is changed to 'Various Artists'
+  to be the same as for MusicBrainz.
 
 
 1.3.15 (October 17, 2015)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ Fixes:
 * :doc:`/plugins/thumbnails`: Fix a crash with Unicode paths. :bug:`1686`
 * :doc:`/plugins/embedart`: The ``remove_art_file`` option now works on import
   (as well as with the explicit command). :bug:`1662` :bug:`1675`
+* :doc:`/plugins/discogs`: New config option to change the default album 
+  artist name if album is V.A. The default is changed to 'Various Artists' to
+  be the same as for MusicBrainz.
 
 
 1.3.15 (October 17, 2015)

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -25,6 +25,14 @@ MusicBrainz.
 If you have a Discogs ID for an album you want to tag, you can also enter it
 at the "enter Id" prompt in the importer.
 
+Configuration
+-------------
+To configure the plugin, make a ``discogs:`` section in your configuration
+file. The available options are:
+
+- **va_name**: Change the name of the albumartist if an album is V.A.
+  Default: ``'Various Artists'`` (Same as MusicBrainz).
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Just a simple config option to change 'various' album artist to the one that MusicBrainz uses: Various Artists. For the purpose of having one V.A. album artist in your library.