### PR TITLE
Fix for crash when sorting by nonexistent field (#1734)

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -767,7 +767,7 @@ class FieldSort(Sort):
         # attributes with different types without falling over.
 
         def key(item):
-            field_val = getattr(item, self.field)
+            field_val = item.get(self.field, '')
             if self.case_insensitive and isinstance(field_val, unicode):
                 field_val = field_val.lower()
             return field_val

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,7 @@ Fixes:
   with some library versions. :bug:`1433`
 * :doc:`/plugins/convert`: Fix a crash with Unicode paths in ``--pretend``
   mode. :bug:`1735`
+* Fix a crash when sorting by nonexistent fields on queries. :bug:`1734`
 
 .. _Emby Server: http://emby.media
 


### PR DESCRIPTION
Fix for #1734 as suggested on the discussion (by simply replacing the line on `dbcore.query.sort()`). Also added a handful of test for making sure it works as expected.