### PR TITLE
info plugin: Allow custom formatting and human-readable lengths 

### DIFF
--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -215,14 +215,14 @@ def make_key_filter(include):
         key = key.replace(r'\*', '.*')
         matchers.append(re.compile(key + '$'))
 
-    def filter(data):
+    def filter_(data):
         filtered = dict()
         for key, value in data.items():
             if any(map(lambda m: m.match(key), matchers)):
                 filtered[key] = value
         return filtered
 
-    return filter
+    return filter_
 
 
 def identity(val):

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -84,7 +84,7 @@ def update_summary(summary, tags):
     return summary
 
 
-def print_data(data, fmt=None, human_length=True):
+def print_data(data, fmt=None):
     """Print, with optional formatting, the fields of a single item.
 
     If no format string `fmt` is passed, the entries on `data` are printed one

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -52,12 +52,10 @@ def tag_data_emitter(path):
         for field in fields:
             tags[field] = getattr(mf, field)
         tags['art'] = mf.art is not None
-        tags['path'] = displayable_path(path)
         # create a temporary Item to take advantage of __format__
-        tags['item'] = Item(db=None, **tags)
+        item = Item.from_path(syspath(path))
 
-        return tags
-
+        return tags, item
     return emitter
 
 
@@ -69,9 +67,9 @@ def library_data(lib, args):
 def library_data_emitter(item):
     def emitter():
         data = dict(item.formatted())
-        data['path'] = displayable_path(item.path)
-        data['item'] = item
-        return data
+        data.pop('path', None)  # path is fetched from item
+
+        return data, item
     return emitter
 
 
@@ -84,20 +82,20 @@ def update_summary(summary, tags):
     return summary
 
 
-def print_data(data, fmt=None):
-    """Print, with optional formatting, the fields of a single item.
+def print_data(data, item=None, fmt=None):
+    """Print, with optional formatting, the fields of a single element.
 
     If no format string `fmt` is passed, the entries on `data` are printed one
     in each line, with the format 'field: value'. If `fmt` is not `None`, the
-    item is printed according to `fmt`, using the `Item.__format__` machinery.
+    `item` is printed according to `fmt`, using the `Item.__format__`
+    machinery.
     """
-    item = data.pop('item', None)
     if fmt:
         # use fmt specified by the user
         ui.print_(format(item, fmt))
         return
 
-    path = data.pop('path', None)
+    path = displayable_path(item.path) if item else None
     formatted = {}
     for key, value in data.iteritems():
         if isinstance(value, list):
@@ -164,22 +162,18 @@ class InfoPlugin(BeetsPlugin):
         summary = {}
         for data_emitter in data_collector(lib, ui.decargs(args)):
             try:
-                data = data_emitter()
+                data, item = data_emitter()
             except (mediafile.UnreadableFileError, IOError) as ex:
                 self._log.error(u'cannot read file: {0}', ex)
                 continue
 
-            path = data.get('path')
-            item = data.get('item')
             data = key_filter(data)
-            data['path'] = path  # always show path
-            data['item'] = item  # always include item, to avoid filtering
             if opts.summarize:
                 update_summary(summary, data)
             else:
                 if not first:
                     ui.print_()
-                print_data(data, opts.format)
+                print_data(data, item, opts.format)
                 first = False
 
         if opts.summarize:

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -90,17 +90,10 @@ def print_data(data, fmt=None, human_length=True):
     If no format string `fmt` is passed, the entries on `data` are printed one
     in each line, with the format 'field: value'. If `fmt` is not `None`, the
     item is printed according to `fmt`, using the `Item.__format__` machinery.
-
-    If `raw_length` is `True`, the `length` field is displayed using its raw
-    value (float with the number of seconds and miliseconds). If not, a human
-    readable form is displayed instead (mm:ss).
     """
     item = data.pop('item', None)
     if fmt:
-        # use fmt specified by the user, prettifying length if needed
-        if human_length and '$length' in fmt:
-            item['humanlength'] = ui.human_seconds_short(item.length)
-            fmt = fmt.replace('$length', '$humanlength')
+        # use fmt specified by the user
         ui.print_(format(item, fmt))
         return
 
@@ -110,10 +103,7 @@ def print_data(data, fmt=None, human_length=True):
         if isinstance(value, list):
             formatted[key] = u'; '.join(value)
         if value is not None:
-            if human_length and key == 'length':
-                formatted[key] = ui.human_seconds_short(float(value))
-            else:
-                formatted[key] = value
+            formatted[key] = value
 
     if len(formatted) == 0:
         return
@@ -143,9 +133,6 @@ class InfoPlugin(BeetsPlugin):
         cmd.parser.add_option('-i', '--include-keys', default=[],
                               action='append', dest='included_keys',
                               help='comma separated list of keys to show')
-        cmd.parser.add_option('-r', '--raw-length', action='store_true',
-                              default=False,
-                              help='display length as seconds')
         cmd.parser.add_format_option(target='item')
         return [cmd]
 
@@ -192,11 +179,11 @@ class InfoPlugin(BeetsPlugin):
             else:
                 if not first:
                     ui.print_()
-                print_data(data, opts.format, not opts.raw_length)
+                print_data(data, opts.format)
                 first = False
 
         if opts.summarize:
-            print_data(summary, human_length=not opts.raw_length)
+            print_data(summary)
 
 
 def make_key_filter(include):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New:
   *exclude* matching music from the results. For example, ``beet list -a
   beatles ^album:1`` will find all your albums by the Beatles except for their
   singles compilation, "1." See :ref:`not_query`. :bug:`819` :bug:`1728`
+* :doc:`/plugins/info`: The plugin now accepts the ``-f/--format`` option for
+  customizing how items are displayed. :bug:`1737`
 
 For developers:
 

--- a/docs/plugins/info.rst
+++ b/docs/plugins/info.rst
@@ -36,6 +36,10 @@ Additional command-line options include:
 * ``--summarize`` or ``-s``: Merge all the information from multiple files
   into a single list of values. If the tags differ across the files, print
   ``[various]``.
+* ``--format`` or ``-f``: Specify a specific format with which to print every
+  item. This uses the same template syntax as beets’ :doc:`path formats
+  </reference/pathformat>`.
+
 
 .. _id3v2: http://id3v2.sourceforge.net
 .. _mp3info: http://www.ibiblio.org/mp3info/

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -52,6 +52,7 @@ class InfoTest(unittest.TestCase, TestHelper):
         self.assertIn('disctitle: DDD', out)
         self.assertIn('genres: a; b; c', out)
         self.assertNotIn('composer:', out)
+        self.remove_mediafile_fixtures()
 
     def test_item_query(self):
         item1, item2 = self.add_item_fixtures(count=2)
@@ -93,6 +94,7 @@ class InfoTest(unittest.TestCase, TestHelper):
         self.assertIn(u'album: AAA', out)
         self.assertIn(u'tracktotal: 5', out)
         self.assertIn(u'title: [various]', out)
+        self.remove_mediafile_fixtures()
 
     def test_include_pattern(self):
         item, = self.add_item_fixtures()

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -107,43 +107,11 @@ class InfoTest(unittest.TestCase, TestHelper):
         self.assertNotIn(u'title:', out)
         self.assertIn(u'album: xxxx', out)
 
-    def test_length_human_library(self):
-        item, = self.add_item_fixtures()
-        item.album = 'loool'
-        item.length = 123.4
-        item.write()
-        item.store()
-
-        out = self.run_with_output('--library')
-        self.assertIn(u'length: 2:03', out)
-
-    def test_length_raw_library(self):
-        item, = self.add_item_fixtures()
-        item.album = 'loool'
-        item.length = 123.4
-        item.write()
-        item.store()
-
-        out = self.run_with_output('--library', '--raw-length')
-        self.assertIn(u'length: 123.4', out)
-
-    def test_length_human_path(self):
-        path = self.create_mediafile_fixture()
-        out = self.run_with_output(path)
-        self.assertIn(u'length: 0:01', out)
-        self.remove_mediafile_fixtures()
-
-    def test_length_raw_path(self):
-        path = self.create_mediafile_fixture()
-        out = self.run_with_output(path, '--raw-length')
-        self.assertIn(u'length: 1.071', out)
-        self.remove_mediafile_fixtures()
-
     def test_custom_format(self):
         self.add_item_fixtures()
         out = self.run_with_output('--library', '--format',
                                    '$track. $title - $artist ($length)')
-        self.assertEqual(u'02. tïtle 0 - the artist (0:01)\n', out)
+        self.assertEqual(u'02. tïtle 0 - the artist (1.1)\n', out)
 
 
 def suite():

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -107,6 +107,44 @@ class InfoTest(unittest.TestCase, TestHelper):
         self.assertNotIn(u'title:', out)
         self.assertIn(u'album: xxxx', out)
 
+    def test_length_human_library(self):
+        item, = self.add_item_fixtures()
+        item.album = 'loool'
+        item.length = 123.4
+        item.write()
+        item.store()
+
+        out = self.run_with_output('--library')
+        self.assertIn(u'length: 2:03', out)
+
+    def test_length_raw_library(self):
+        item, = self.add_item_fixtures()
+        item.album = 'loool'
+        item.length = 123.4
+        item.write()
+        item.store()
+
+        out = self.run_with_output('--library', '--raw-length')
+        self.assertIn(u'length: 123.4', out)
+
+    def test_length_human_path(self):
+        path = self.create_mediafile_fixture()
+        out = self.run_with_output(path)
+        self.assertIn(u'length: 0:01', out)
+        self.remove_mediafile_fixtures()
+
+    def test_length_raw_path(self):
+        path = self.create_mediafile_fixture()
+        out = self.run_with_output(path, '--raw-length')
+        self.assertIn(u'length: 1.071', out)
+        self.remove_mediafile_fixtures()
+
+    def test_custom_format(self):
+        self.add_item_fixtures()
+        out = self.run_with_output('--library', '--format',
+                                   '$track. $title - $artist ($length)')
+        self.assertEqual(u'02. tïtle 0 - the artist (0:01)\n', out)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
Work in progress for implementing the feature discussed on #1689, as the workflow proposed by @awesomer would be pretty much aligned with one of my long-term wishlist for my library (ie. a neat way to assist in adding obscure/missing albums to MusicBrainz without the need for extra tools), and hopefully encourage others contributing back to MusicBrainz.

These commits intend to implement the suggested initial changes on the `info` plugin:
> A good first step, should anyone choose to accept it, would be to extend the info plugin so it can be configured to output using formatting, like the list command.

The command now accepts the standard formatting argument (via `cmd.parser.add_format_option`), relying on the `Item.__format__` machinery for formatting. Modifications have been made so an `Item` (either directly retrieved from the library if using `library_data_emitter`, or a "fake" temporary one built from the media file is using `tag_data_emitter`) is available to `print_data()`.

> At the same time, it would be a good idea to format length as a time by default—nobody probably wants to see a raw number of seconds.

Makes much sense to me! Just in case the raw number of seconds is useful to someone, an argument (`--raw-length`) has been added to switch between raw length and human-readable length (human-readable being the default).

I'd love some feedback on the current work, and also some thoughts on the preferred way for implementing the next steps. My thoughts go along the line of extending the `info` plugin with a listener for the "*MusicBrainz match not found*" event, but I'm not sure if this functionality would be better fitted into a less generic plugin?
