### PR TITLE
Documentation update: followup to #1736, fix typo on inline.rst

### DIFF
--- a/docs/plugins/inline.rst
+++ b/docs/plugins/inline.rst
@@ -6,9 +6,9 @@ it, you can define template fields in your beets configuration file and refer
 to them from your template strings in the ``paths:`` section (see
 :doc:`/reference/config/`).
 
-To use the `ìnline`` plugin, enable it in your configuration
+To use the ``inline`` plugin, enable it in your configuration
 (see :ref:`using-plugins`).
-Then, make a `item_fields:`` block in your config file. Under this key, every line defines a
+Then, make a ``item_fields:`` block in your config file. Under this key, every line defines a
 new template field; the key is the name of the field (you'll use the name to
 refer to the field in your templates) and the value is a Python expression or
 function body. The Python code has all of a track's fields in scope, so you can

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -261,5 +261,9 @@ sort order: ``Bar foo Qux``. This behavior can be changed with the
 result in lower-case values being placed after upper-case values, e.g.,
 ``Bar Qux foo``.
 
+Note that when sorting by fields that are not present on all items (such as
+flexible fields, or those defined by plugins) in *ascending* order,  the items
+that lack that particular field will be listed at the *beginning* of the list.
+
 You can set the default sorting behavior with the :ref:`sort_item` and
 :ref:`sort_album` configuration options.


### PR DESCRIPTION
* Add note about ordering when sorting by custom-fields on query.rst (as per https://github.com/sampsyo/beets/pull/1736#discussion_r45827719)
* Fix typo on inline.rst.

Again, I'm issuing it as a pull request, in the hopes of having it double checked while my *beets-documentation-style* skills are not fully developed!