### PR TITLE
Fetchart plugin: new google custom search engine backend

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -169,8 +169,8 @@ class GoogleImages(ArtSource):
             return
         search_string = (album.albumartist + ',' + album.album).encode('utf-8')
         response = self.request(self.URL, params={
-            'key': self._config['google_API_key'].get(),
-            'cx': self._config['google_engine_ID'].get(),
+            'key': self._config['google_key'].get(),
+            'cx': self._config['google_engine'].get(),
             'q': search_string,
             'searchType': 'image'
         })
@@ -424,10 +424,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             'cautious': False,
             'cover_names': ['cover', 'front', 'art', 'album', 'folder'],
             'sources': ['coverart', 'itunes', 'amazon', 'albumart'],
-            'google_API_key': None,
-            'google_engine_ID': u'001442825323518660753:hrh5ch1gjzm',
+            'google_key': None,
+            'google_engine': u'001442825323518660753:hrh5ch1gjzm',
         })
-        self.config['google_API_key'].redact = True
+        self.config['google_key'].redact = True
 
         # Holds paths to downloaded images between fetching them and
         # placing them in the filesystem.
@@ -445,7 +445,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         available_sources = list(SOURCES_ALL)
         if not HAVE_ITUNES and u'itunes' in available_sources:
             available_sources.remove(u'itunes')
-        if not self.config['google_API_key'].get() and \
+        if not self.config['google_key'].get() and \
                 u'google' in available_sources:
             available_sources.remove(u'google')
         sources_name = plugins.sanitize_choices(

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -165,7 +165,7 @@ class GoogleImages(ArtSource):
         given an album title and interpreter.
         """
         self._log.debug('fetching art from google...')
-        api_key = config['fetchart']['google_api_key'].get()
+        api_key = config['fetchart']['google_API_key'].get()
         engine_id = config['fetchart']['google_engine_ID'].get()
         self._log.debug('API Key: ' + api_key)
         self._log.debug('Engine ID: ' + engine_id)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -176,7 +176,12 @@ class GoogleImages(ArtSource):
         })
 
         # Get results using JSON.
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError:
+            self._log.debug(u'google: error loading response: {}'.format(response.text))
+            return
+
         if 'error' in data:
             reason = data['error']['errors'][0]['reason']
             self._log.debug(u'google fetchart error: {0}', reason)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -179,7 +179,8 @@ class GoogleImages(ArtSource):
         try:
             data = response.json()
         except ValueError:
-            self._log.debug(u'google: error loading response: {}'.format(response.text))
+            self._log.debug(u'google: error loading response: {}'
+                            .format(response.text))
             return
 
         if 'error' in data:
@@ -449,7 +450,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             available_sources.remove(u'google')
         sources_name = plugins.sanitize_choices(
             self.config['sources'].as_str_seq(), available_sources)
-        self.sources = [ART_SOURCES[s](self._log, self.config) for s in sources_name]
+        self.sources = [ART_SOURCES[s](self._log, self.config)
+                        for s in sources_name]
         self.fs_source = FileSystem(self._log, self.config)
 
     # Asynchronous; after music is added to the library.

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -169,9 +169,6 @@ class GoogleImages(ArtSource):
         engine_id = config['fetchart']['google_engine_ID'].get()
         self._log.debug('API Key: ' + api_key)
         self._log.debug('Engine ID: ' + engine_id)
-        if not api_key:
-            self._log.debug(u'google api key not set')
-            return
         if not (album.albumartist and album.album):
             return
         search_string = (album.albumartist + ',' + album.album).encode('utf-8')
@@ -446,6 +443,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         available_sources = list(SOURCES_ALL)
         if not HAVE_ITUNES and u'itunes' in available_sources:
             available_sources.remove(u'itunes')
+        if not self.config['google_API_key'].get() and \
+                u'google' in available_sources:
+            available_sources.remove(u'google')
         sources_name = plugins.sanitize_choices(
             self.config['sources'].as_str_seq(), available_sources)
         self.sources = [ART_SOURCES[s](self._log) for s in sources_name]

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -96,8 +96,9 @@ class RequestMixin(object):
 # ART SOURCES ################################################################
 
 class ArtSource(RequestMixin):
-    def __init__(self, log):
+    def __init__(self, log, config):
         self._log = log
+        self._config = config
 
     def get(self, album):
         raise NotImplementedError()
@@ -168,8 +169,8 @@ class GoogleImages(ArtSource):
             return
         search_string = (album.albumartist + ',' + album.album).encode('utf-8')
         response = self.request(self.URL, params={
-            'key': config['fetchart']['google_API_key'].get(),
-            'cx': config['fetchart']['google_engine_ID'].get(),
+            'key': self._config['google_API_key'].get(),
+            'cx': self._config['google_engine_ID'].get(),
             'q': search_string,
             'searchType': 'image'
         })
@@ -443,8 +444,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             available_sources.remove(u'google')
         sources_name = plugins.sanitize_choices(
             self.config['sources'].as_str_seq(), available_sources)
-        self.sources = [ART_SOURCES[s](self._log) for s in sources_name]
-        self.fs_source = FileSystem(self._log)
+        self.sources = [ART_SOURCES[s](self._log, self.config) for s in sources_name]
+        self.fs_source = FileSystem(self._log, self.config)
 
     # Asynchronous; after music is added to the library.
     def fetch_art(self, session, task):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -164,11 +164,8 @@ class GoogleImages(ArtSource):
         """Return art URL from google custom search engine
         given an album title and interpreter.
         """
-        self._log.debug('fetching art from google...')
         api_key = config['fetchart']['google_API_key'].get()
         engine_id = config['fetchart']['google_engine_ID'].get()
-        self._log.debug('API Key: ' + api_key)
-        self._log.debug('Engine ID: ' + engine_id)
         if not (album.albumartist and album.album):
             return
         search_string = (album.albumartist + ',' + album.album).encode('utf-8')

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -96,9 +96,8 @@ class RequestMixin(object):
 # ART SOURCES ################################################################
 
 class ArtSource(RequestMixin):
-    def __init__(self, log, config):
+    def __init__(self, log):
         self._log = log
-        self._config = config
 
     def get(self, album):
         raise NotImplementedError()
@@ -166,8 +165,8 @@ class GoogleImages(ArtSource):
         given an album title and interpreter.
         """
         self._log.debug('fetching art from google...')
-        api_key = self._config['google_api_key'].get()
-        engine_id = self._config['google_engine_ID'].get()
+        api_key = config['fetchart']['google_api_key'].get()
+        engine_id = config['fetchart']['google_engine_ID'].get()
         self._log.debug('API Key: ' + api_key)
         self._log.debug('Engine ID: ' + engine_id)
         if not api_key:
@@ -449,8 +448,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             available_sources.remove(u'itunes')
         sources_name = plugins.sanitize_choices(
             self.config['sources'].as_str_seq(), available_sources)
-        self.sources = [ART_SOURCES[s](self._log, self.config) for s in sources_name]
-        self.fs_source = FileSystem(self._log, self.config)
+        self.sources = [ART_SOURCES[s](self._log) for s in sources_name]
+        self.fs_source = FileSystem(self._log)
 
     # Asynchronous; after music is added to the library.
     def fetch_art(self, session, task):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -164,14 +164,12 @@ class GoogleImages(ArtSource):
         """Return art URL from google custom search engine
         given an album title and interpreter.
         """
-        api_key = config['fetchart']['google_API_key'].get()
-        engine_id = config['fetchart']['google_engine_ID'].get()
         if not (album.albumartist and album.album):
             return
         search_string = (album.albumartist + ',' + album.album).encode('utf-8')
         response = self.request(self.URL, params={
-            'key': api_key,
-            'cx': engine_id,
+            'key': config['fetchart']['google_API_key'].get(),
+            'cx': config['fetchart']['google_engine_ID'].get(),
             'q': search_string,
             'searchType': 'image'
         })

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -50,12 +50,18 @@ file. The available options are:
 - **sources**: List of sources to search for images. An asterisk `*` expands
   to all available sources.
   Default: ``coverart itunes amazon albumart``, i.e., everything but
-  ``wikipedia``. Enable those two sources for more matches at
+  ``wikipedia`` and ``google``. Enable those two sources for more matches at
   the cost of some speed.
+- **google_API_key**: Your Google API key (to enable the Google Custom Search
+  backend).
+  Default: None.
+- **google_engine_ID**: The custom search engine to use.
+  Default: The `beets custom search engine`_, which searches the entire web.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.
 
+.. _beets custom search engine: https://cse.google.com.au:443/cse/publicurl?cx=001442825323518660753:hrh5ch1gjzm
 .. _Pillow: https://github.com/python-pillow/Pillow
 .. _ImageMagick: http://www.imagemagick.org/
 
@@ -137,6 +143,24 @@ Once the library is installed, the plugin will use it to search automatically.
 .. _python-itunes: https://github.com/ocelma/python-itunes
 .. _pip: http://pip.openplans.org/
 
+Google custom search
+''''''''''''''''''''
+
+To use the google image search backend you need to
+`register for a Google API key`_. Set the ``google_API_key`` configuration
+option to your key, then add ``google`` to the list of sources in your
+configuration.
+
+.. _register for a Google API key: https://code.google.com/apis/console.
+
+Optionally, you can `define a custom search engine`_. Get your search engine's
+token and use it for your ``google_engine_ID`` configuration option. The
+default engine searches the entire web for cover art.
+
+.. _define a custom search engine: http://www.google.com/cse/all
+
+Note that the Google custom search API is limited to 100 queries per day.
+After that, the fetchart plugin will fall back on other declared data sources.
 
 Embedding Album Art
 -------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -52,10 +52,10 @@ file. The available options are:
   Default: ``coverart itunes amazon albumart``, i.e., everything but
   ``wikipedia`` and ``google``. Enable those two sources for more matches at
   the cost of some speed.
-- **google_API_key**: Your Google API key (to enable the Google Custom Search
+- **google_key**: Your Google API key (to enable the Google Custom Search
   backend).
   Default: None.
-- **google_engine_ID**: The custom search engine to use.
+- **google_engine**: The custom search engine to use.
   Default: The `beets custom search engine`_, which searches the entire web.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
@@ -147,14 +147,14 @@ Google custom search
 ''''''''''''''''''''
 
 To use the google image search backend you need to
-`register for a Google API key`_. Set the ``google_API_key`` configuration
+`register for a Google API key`_. Set the ``google_key`` configuration
 option to your key, then add ``google`` to the list of sources in your
 configuration.
 
 .. _register for a Google API key: https://code.google.com/apis/console.
 
 Optionally, you can `define a custom search engine`_. Get your search engine's
-token and use it for your ``google_engine_ID`` configuration option. The
+token and use it for your ``google_engine`` configuration option. The
 default engine searches the entire web for cover art.
 
 .. _define a custom search engine: http://www.google.com/cse/all

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -226,6 +226,41 @@ class AAOTest(UseThePlugin):
         self.assertEqual(list(res), [])
 
 
+class GoogleImageTest(UseThePlugin):
+    def setUp(self):
+        super(GoogleImageTest, self).setUp()
+        self.source = fetchart.GoogleImages(logger, self.plugin.config)
+
+    @responses.activate
+    def run(self, *args, **kwargs):
+        super(GoogleImageTest, self).run(*args, **kwargs)
+
+    def mock_response(self, url, json):
+        responses.add(responses.GET, url, body=json,
+                      content_type='application/json')
+
+    def test_google_art_finds_image(self):
+        album = _common.Bag(albumartist="some artist", album="some album")
+        json = b'{"items": [{"link": "url_to_the_image"}]}'
+        self.mock_response(fetchart.GoogleImages.URL, json)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url)[0], 'url_to_the_image')
+
+    def test_google_art_returns_no_result_when_error_received(self):
+        album = _common.Bag(albumartist="some artist", album="some album")
+        json = b'{"error": {"errors": [{"reason": "some reason"}]}}'
+        self.mock_response(fetchart.GoogleImages.URL, json)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url), [])
+
+    def test_google_art_returns_no_result_with_malformed_response(self):
+        album = _common.Bag(albumartist="some artist", album="some album")
+        json = b"""bla blup"""
+        self.mock_response(fetchart.GoogleImages.URL, json)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url), [])
+
+
 class ArtImporterTest(UseThePlugin):
     def setUp(self):
         super(ArtImporterTest, self).setUp()

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -65,13 +65,13 @@ class FetchImageTest(UseThePlugin):
         self.assertNotEqual(artpath, None)
 
 
-class FSArtTest(_common.TestCase):
+class FSArtTest(UseThePlugin):
     def setUp(self):
         super(FSArtTest, self).setUp()
         self.dpath = os.path.join(self.temp_dir, 'arttest')
         os.mkdir(self.dpath)
 
-        self.source = fetchart.FileSystem(logger)
+        self.source = fetchart.FileSystem(logger, self.plugin.config)
 
     def test_finds_jpg_in_directory(self):
         _common.touch(os.path.join(self.dpath, 'a.jpg'))
@@ -190,13 +190,13 @@ class CombinedTest(UseThePlugin):
         self.assertEqual(len(responses.calls), 0)
 
 
-class AAOTest(_common.TestCase):
+class AAOTest(UseThePlugin):
     ASIN = 'xxxx'
     AAO_URL = 'http://www.albumart.org/index_detail.php?asin={0}'.format(ASIN)
 
     def setUp(self):
         super(AAOTest, self).setUp()
-        self.source = fetchart.AlbumArtOrg(logger)
+        self.source = fetchart.AlbumArtOrg(logger, self.plugin.config)
 
     @responses.activate
     def run(self, *args, **kwargs):


### PR DESCRIPTION
This restores the fetchart plugin’s google backend (see #1760) using the google custom search API.
Configuration options are identical to the lyrics plugin.