### PR TITLE
play: remove dead code, fix error catching

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -131,11 +131,6 @@ class PlayPlugin(BeetsPlugin):
         except OSError as exc:
             raise ui.UserError("Could not play the music playlist: "
                                "{0}".format(exc))
-        finally:
-            if not raw:
-                self._log.debug('Removing temporary playlist: {}',
-                                open_args[0])
-                util.remove(open_args[0])
 
     def _create_tmp_playlist(self, paths_list):
         """Create a temporary .m3u file. Return the filename.

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -129,7 +129,7 @@ class PlayPlugin(BeetsPlugin):
         try:
             util.interactive_open(open_args, command_str)
         except OSError as exc:
-            raise ui.UserError("Could not play the music playlist: "
+            raise ui.UserError("Could not play the query: "
                                "{0}".format(exc))
 
     def _create_tmp_playlist(self, paths_list):


### PR DESCRIPTION
A try at fixing #1600 .

I would argue that for the moment, this is where the fix should stop. Until new user feedback comes, I think the (potential) disadvantages of trying to delete the temporary playlists as we go do outweigh the advantages.

Advantages:
* Privacy: do not leak playlists in `/tmp/`, which is accessible by anyone.
* Storage: do not load `/tmp/` with useless playlists.

However those two seem pretty thin (especially the second one these days). (Self-advertisement: if those constraints are really problematic, the `raw` option of `beets-play` turns out to be a good solution!)

Disadvantages:
* As the playlist consumer is a completely arbitrary choice from the user, it is impossible to know from which point on the playlist can be safely deleted.

This one seems pretty big to me. For example, vlc, for the reasons described in #1578 could potentially try to open a playlist long after `beet play [query]` is called if one is not careful (and not even in the original order too!).

If we absolutely still want to prevent leakage, the solution proposed by @sampsyo seems like the least bad to me:

>Here's one silly idea: when starting play, remove the playlist from the last execution. That way, we'll only leak one file at most—at the slight cost of a potential race if someone invokes play twice really quickly.

It could be implemented pretty easily. However, two things come to mind:
* To not rely on a stored state, I would argue the best way to do this would be to create the playlists with a 'proprietary' suffix, like `*.beetplaylist.m3u` for example, and then look for this template in the temporary directory (easily provided by [`tempfile.gettempdir()`](https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir)) and delete all matches. This could get problematic if `/tmp/` is really big for some reason
* This introduces one more reliance on the underlying os (file deletion, find the tempdir).