### PR TITLE
Fix lastimport #1574 (LastFM API change)

### DIFF
--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -210,17 +210,6 @@ def process_tracks(lib, tracks, log):
                 dbcore.query.MatchQuery('mb_trackid', trackid)
             ).get()
 
-        # Otherwise try artist/title/album
-        if song is None:
-            log.debug(u'no match for mb_trackid {0}, trying by '
-                      u'artist/title/album', trackid)
-            query = dbcore.AndQuery([
-                dbcore.query.SubstringQuery('artist', artist),
-                dbcore.query.SubstringQuery('title', title),
-                dbcore.query.SubstringQuery('album', album)
-            ])
-            song = lib.items(query).get()
-
         # If not, try just artist/title
         if song is None:
             log.debug(u'no album match, trying by artist/title')

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -194,7 +194,7 @@ def process_tracks(lib, tracks, log):
     log.info('Received {0} tracks in this page, processing...', total)
 
     for num in xrange(0, total):
-        song = ''
+        song = None
         trackid = tracks[num]['mbid'].strip()
         artist = tracks[num]['artist'].get('name', '').strip()
         title = tracks[num]['name'].strip()
@@ -211,7 +211,7 @@ def process_tracks(lib, tracks, log):
             ).get()
 
         # Otherwise try artist/title/album
-        if not song:
+        if song is None:
             log.debug(u'no match for mb_trackid {0}, trying by '
                       u'artist/title/album', trackid)
             query = dbcore.AndQuery([
@@ -222,7 +222,7 @@ def process_tracks(lib, tracks, log):
             song = lib.items(query).get()
 
         # If not, try just artist/title
-        if not song:
+        if song is None:
             log.debug(u'no album match, trying by artist/title')
             query = dbcore.AndQuery([
                 dbcore.query.SubstringQuery('artist', artist),
@@ -231,7 +231,7 @@ def process_tracks(lib, tracks, log):
             song = lib.items(query).get()
 
         # Last resort, try just replacing to utf-8 quote
-        if not song:
+        if song is None:
             title = title.replace("'", u'\u2019')
             log.debug(u'no title match, trying utf-8 single quote')
             query = dbcore.AndQuery([
@@ -240,7 +240,7 @@ def process_tracks(lib, tracks, log):
             ])
             song = lib.items(query).get()
 
-        if song:
+        if song is not None:
             count = int(song.get('play_count', 0))
             new_count = int(tracks[num]['playcount'])
             log.debug(u'match: {0} - {1} ({2}) '

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ Fixes:
   anymore. :bug:`1583`
 * :doc:`/plugins/play`: Fix a regression in the last version where there was
   no default command. :bug:`1793`
+* :doc:`/plugins/lastimport`: Switched API method from library.getTracks to
+  user.getTopTracks. This fixes :bug:`1574`, which was caused by the former API
+  method being removed. Also moved from custom HTTP requests to using pylast
+  library.
 
 
 1.3.16 (December 28, 2015)

--- a/docs/plugins/lastimport.rst
+++ b/docs/plugins/lastimport.rst
@@ -6,6 +6,8 @@ library into beets' database. You can later create :doc:`smart playlists
 </plugins/smartplaylist>` by querying ``play_count`` and do other fun stuff
 with this field.
 
+.. _Last.fm: http://last.fm
+
 Installation
 ------------
 
@@ -21,8 +23,8 @@ Next, add your Last.fm username to your beets configuration file::
     lastfm:
         user: beetsfanatic
 
-.. _requests: http://docs.python-requests.org/en/latest/
-.. _Last.fm: http://last.fm
+.. _pip: http://www.pip-installer.org/
+.. _pylast: http://code.google.com/p/pylast/
 
 Importing Play Counts
 ---------------------

--- a/docs/plugins/lastimport.rst
+++ b/docs/plugins/lastimport.rst
@@ -9,10 +9,12 @@ with this field.
 Installation
 ------------
 
-To use the ``lastimport`` plugin, first enable it in your configuration (see
-:ref:`using-plugins`). Then install the `requests`_ library by typing::
+The plugin requires `pylast`_, which you can install using `pip`_ by typing::
 
-    pip install requests
+    pip install pylast
+
+After you have pylast installed, enable the ``lastimport`` plugin in your
+configuration (see :ref:`using-plugins`).
 
 Next, add your Last.fm username to your beets configuration file::
 


### PR DESCRIPTION
Fixes #1574 by changing the API method from library.getTracks to user.getTopTracks, which returns similar information (mbid, artist, title, playcount).

Also, I've replaced the custom HTTP request (using requests) with the pylast library, which is already a dependency of lastgenre.